### PR TITLE
Network vis

### DIFF
--- a/uvdat/core/serializers.py
+++ b/uvdat/core/serializers.py
@@ -18,8 +18,6 @@ class NetworkNodeSerializer(serializers.ModelSerializer):
 
 
 class DatasetSerializer(serializers.ModelSerializer):
-    network_nodes = NetworkNodeSerializer(many=True)
-
     class Meta:
         model = Dataset
         fields = '__all__'

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from uvdat.core.models import City, Dataset
-from uvdat.core.serializers import CitySerializer, DatasetSerializer
+from uvdat.core.serializers import CitySerializer, DatasetSerializer, NetworkNodeSerializer
 from uvdat.core.tasks import convert_raw_archive
 
 TILES_DIR = tempfile.TemporaryDirectory()
@@ -40,6 +40,18 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
                 return HttpResponse(json.dumps(tile.__next__()), status=200)
             except StopIteration:
                 return HttpResponse(status=404)
+
+    @action(
+        detail=True,
+        methods=['get'],
+        url_path=r'network',
+        url_name='network',
+    )
+    def get_network_nodes(self, request, **kwargs):
+        dataset = self.get_object()
+        return Response(
+            [NetworkNodeSerializer(n).data for n in dataset.network_nodes.all()], status=200
+        )
 
     @action(
         detail=True,

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./auth";
-import { City, Dataset } from "@/types";
+import { City, Dataset, NetworkNode } from "@/types";
 
 export async function getCities(): Promise<City[]> {
   return (await apiClient.get("cities")).data.results;
@@ -11,4 +11,10 @@ export async function getDataset(datasetId: number): Promise<Dataset> {
 
 export async function convertDataset(datasetId: number): Promise<Dataset> {
   return (await apiClient.get(`datasets/${datasetId}/convert`)).data;
+}
+
+export async function getDatasetNetwork(
+  datasetId: number
+): Promise<NetworkNode[]> {
+  return (await apiClient.get(`datasets/${datasetId}/network`)).data;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -33,3 +33,12 @@ export interface Feature {
     [key: string]: string | object;
   };
 }
+
+export interface NetworkNode {
+  id: number;
+  location: number[];
+  name: string;
+  properties: object;
+  dataset: number;
+  adjacent_nodes: number[];
+}

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,9 +1,14 @@
 import TileLayer from "ol/layer/Tile.js";
+import VectorLayer from "ol/layer/Vector";
 import VectorTileLayer from "ol/layer/VectorTile.js";
 import XYZSource from "ol/source/XYZ.js";
+import VectorSource from "ol/source/Vector";
 import VectorTileSource from "ol/source/VectorTile.js";
 import GeoJSON from "ol/format/GeoJSON.js";
 import { Fill, Stroke, Circle, Style } from "ol/style.js";
+import { Feature } from "ol";
+import { LineString, Point } from "ol/geom";
+import { fromLonLat } from "ol/proj";
 
 import { baseURL } from "@/api/auth";
 import { map } from "@/store";
@@ -112,4 +117,61 @@ export function addDatasetLayerToMap(dataset, zIndex) {
       })
     );
   }
+}
+
+export function addNetworkLayerToMap(dataset, nodes) {
+  const source = new VectorSource();
+  const features = [];
+  const visitedNodes = [];
+  nodes.forEach((node) => {
+    features.push(
+      new Feature(
+        Object.assign(node.properties, {
+          name: node.name,
+          geometry: new Point(fromLonLat(node.location.toReversed())),
+        })
+      )
+    );
+    node.adjacent_nodes.forEach((adjId) => {
+      if (!visitedNodes.includes(adjId)) {
+        const adjNode = nodes.find((n) => n.id === adjId);
+        features.push(
+          new Feature({
+            geometry: new LineString([
+              fromLonLat(node.location.toReversed()),
+              fromLonLat(adjNode.location.toReversed()),
+            ]),
+          })
+        );
+      }
+    });
+    visitedNodes.push(node.id);
+  });
+  source.addFeatures(features);
+
+  const fill = new Fill({
+    color: "#ffffffff",
+  });
+  const stroke = new Stroke({
+    color: "#000000ff",
+    width: 3,
+  });
+  const style = new Style({
+    image: new Circle({
+      fill: fill,
+      stroke: stroke,
+      radius: 7,
+    }),
+    fill: fill,
+    stroke: stroke,
+  });
+  const layer = new VectorLayer({
+    properties: {
+      datasetId: dataset.id,
+      network: true,
+    },
+    source,
+    style,
+  });
+  map.value.addLayer(layer);
 }


### PR DESCRIPTION
This PR adds a toggle switch to the Options panel for any dataset where `network=True`. 
When enabled, the normal layer is hidden and a new layer with the network representation is created (or shown if it already exists). For now, this visualization is static and does not have special interaction options (such as marking nodes as inactive). It does have the tooltip interaction to view the details of a node.

![image](https://github.com/OpenGeoscience/uvdat/assets/44912689/65b499f0-b7ae-47d7-9c76-0944dbb7573f)
