### PR TITLE
Blank analysis task

### DIFF
--- a/sample_data/populate_server.py
+++ b/sample_data/populate_server.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 import requests
 
 from uvdat.core.models import City, Dataset
-from uvdat.core.tasks import convert_raw_archive
+from uvdat.core.tasks.conversion import convert_raw_archive
 
 
 class Command(BaseCommand):

--- a/uvdat/core/tasks/conversion.py
+++ b/uvdat/core/tasks/conversion.py
@@ -2,11 +2,9 @@ import json
 from pathlib import Path
 import tempfile
 import zipfile
-import shapely
 
 from celery import shared_task
 from django.core.files.base import ContentFile
-from django.contrib.gis.geos import Point
 from geojson2vt import geojson2vt, vt2geojson
 import geopandas
 import large_image_converter
@@ -14,8 +12,9 @@ import numpy
 import rasterio
 import shapefile
 
-from uvdat.core.models import Dataset, NetworkNode
+from uvdat.core.models import Dataset
 from uvdat.core.utils import add_styling
+from uvdat.core.tasks.networks import save_network_nodes
 
 
 @shared_task
@@ -166,135 +165,3 @@ def convert_shape_file_archive(dataset_id):
         print(f'\t Shapefile to GeoJSON conversion complete for {dataset.name}.')
         dataset.processing = False
         dataset.save()
-
-
-def save_network_nodes(dataset, geodata):
-    connection_column = None
-    connection_column_delimiter = None
-    node_id_column = None
-    if dataset.metadata:
-        connection_column = dataset.metadata.get('connection_column')
-        connection_column_delimiter = dataset.metadata.get('connection_column_delimiter')
-        node_id_column = dataset.metadata.get('node_id_column')
-    if connection_column is None or connection_column not in geodata.columns:
-        raise ValueError(
-            f'This dataset does not specify a valid \
-                "connection_column" in its options. Column options are {geodata.columns}.'
-        )
-    if connection_column_delimiter is None:
-        raise ValueError(
-            'This dataset does not specify a "connection_column_delimiter" in its options.'
-        )
-    if node_id_column is None or node_id_column not in geodata.columns:
-        raise ValueError(
-            f'This dataset does not specify a valid \
-                "node_id_column" in its options. Column options are {geodata.columns}.'
-        )
-
-    geodata = geodata.copy()
-    geodata[connection_column].fillna('', inplace=True)
-    edge_set = geodata[geodata.geom_type != 'Point']
-    node_set = geodata[geodata.geom_type == 'Point']
-
-    adjacencies = {}
-    total_adjacencies = 0
-    unique_routes = node_set[connection_column].drop_duplicates()
-    unique_routes = unique_routes[~unique_routes.str.contains(connection_column_delimiter)]
-    for unique_route in unique_routes:
-        nodes = node_set[node_set[connection_column].str.contains(unique_route, regex=False)]
-        edges = edge_set[edge_set[connection_column].str.contains(unique_route, regex=False)]
-
-        # create one route line from all edges in this group
-        if len(edges) < 1:
-            continue
-        route = edges.unary_union
-        if route.geom_type == 'MultiLineString':
-            route = shapely.ops.linemerge(route)
-        route = shapely.extract_unique_points(route.segmentize(10))
-        route_points = geopandas.GeoDataFrame(geometry=list(route.geoms)).set_crs(node_set.crs)
-
-        # convert both nodes and route to a projected crs
-        # for better accuracy of the sjoin_nearest function to follow
-        nodes = nodes.to_crs(3857)
-        route_points = route_points.to_crs(3857)
-
-        # along the points of the route, find the nodes that are nearest (in order of the route points)
-        route_points_nearest_nodes = route_points.sjoin_nearest(nodes).sort_index()
-        route_nodes = list(
-            route_points_nearest_nodes.drop_duplicates(subset=[node_id_column])[node_id_column]
-        )
-
-        # print(unique_route, route_nodes)
-
-        # record adjacencies from the ordered route nodes list
-        for i in range(len(route_nodes) - 1):
-            current_node_id = route_nodes[i]
-            adjacent_node_id = route_nodes[i + 1]
-
-            if current_node_id not in adjacencies:
-                adjacencies[current_node_id] = []
-            if adjacent_node_id not in adjacencies:
-                adjacencies[adjacent_node_id] = []
-
-            if adjacent_node_id not in adjacencies[current_node_id]:
-                adjacencies[current_node_id].append(adjacent_node_id)
-                total_adjacencies += 1
-            if current_node_id not in adjacencies[adjacent_node_id]:
-                adjacencies[adjacent_node_id].append(current_node_id)
-
-    # print('total connections=', total_adjacencies)
-
-    # Create all NetworkNode objects first, then populate adjacencies after.
-    dataset.network_nodes.all().delete()
-    node_set = node_set.drop_duplicates(subset=[node_id_column])
-    for i, node in node_set.iterrows():
-        properties = node.drop(['geometry', 'colors', node_id_column])
-        properties = properties.replace(numpy.nan, 'None')
-        location = Point(x=node.geometry.x, y=node.geometry.y)
-        NetworkNode(
-            name=node[node_id_column],
-            dataset=dataset,
-            location=location,
-            properties=dict(properties),
-        ).save()
-    for i, node in node_set.iterrows():
-        adjacent_node_ids = adjacencies.get(node[node_id_column])
-        if not adjacent_node_ids:
-            continue
-        node_object = NetworkNode.objects.get(name=node[node_id_column])
-        node_object.adjacent_nodes.set(NetworkNode.objects.filter(name__in=adjacent_node_ids))
-        node_object.save()
-
-    # network_to_geojson(dataset)
-
-
-def network_to_geojson(dataset):
-    # create a geojson representation for testing
-    write_geojson = True
-    if write_geojson:
-        import geojson
-
-        point_features = []
-        edge_features = {}
-        for node in NetworkNode.objects.filter(dataset=dataset):
-            point_features.append(
-                geojson.Feature(
-                    geometry=geojson.Point(node.location),
-                    properties=dict(node.properties, name=node.name),
-                )
-            )
-            for adj in node.adjacent_nodes.all():
-                connection_key = '/'.join(sorted([node.name, adj.name]))
-                if connection_key not in edge_features:
-                    edge_features[connection_key] = geojson.Feature(
-                        geometry=geojson.LineString(
-                            (
-                                (node.location.x, node.location.y),
-                                (adj.location.x, adj.location.y),
-                            )
-                        )
-                    )
-
-        feature_collection = geojson.FeatureCollection([*point_features, *edge_features.values()])
-        with open('temp.geojson', 'w') as f:
-            geojson.dump(feature_collection, f)

--- a/uvdat/core/tasks/networks.py
+++ b/uvdat/core/tasks/networks.py
@@ -1,0 +1,111 @@
+import shapely
+import geopandas
+import numpy
+
+from celery import shared_task
+from django.contrib.gis.geos import Point
+
+from uvdat.core.models import NetworkNode
+
+
+def save_network_nodes(dataset, geodata):
+    connection_column = None
+    connection_column_delimiter = None
+    node_id_column = None
+    if dataset.metadata:
+        connection_column = dataset.metadata.get('connection_column')
+        connection_column_delimiter = dataset.metadata.get('connection_column_delimiter')
+        node_id_column = dataset.metadata.get('node_id_column')
+    if connection_column is None or connection_column not in geodata.columns:
+        raise ValueError(
+            f'This dataset does not specify a valid \
+                "connection_column" in its options. Column options are {geodata.columns}.'
+        )
+    if connection_column_delimiter is None:
+        raise ValueError(
+            'This dataset does not specify a "connection_column_delimiter" in its options.'
+        )
+    if node_id_column is None or node_id_column not in geodata.columns:
+        raise ValueError(
+            f'This dataset does not specify a valid \
+                "node_id_column" in its options. Column options are {geodata.columns}.'
+        )
+
+    geodata = geodata.copy()
+    geodata[connection_column].fillna('', inplace=True)
+    edge_set = geodata[geodata.geom_type != 'Point']
+    node_set = geodata[geodata.geom_type == 'Point']
+
+    adjacencies = {}
+    total_adjacencies = 0
+    unique_routes = node_set[connection_column].drop_duplicates()
+    unique_routes = unique_routes[~unique_routes.str.contains(connection_column_delimiter)]
+    for unique_route in unique_routes:
+        nodes = node_set[node_set[connection_column].str.contains(unique_route, regex=False)]
+        edges = edge_set[edge_set[connection_column].str.contains(unique_route, regex=False)]
+
+        # create one route line from all edges in this group
+        if len(edges) < 1:
+            continue
+        route = edges.unary_union
+        if route.geom_type == 'MultiLineString':
+            route = shapely.ops.linemerge(route)
+        route = shapely.extract_unique_points(route.segmentize(10))
+        route_points = geopandas.GeoDataFrame(geometry=list(route.geoms)).set_crs(node_set.crs)
+
+        # convert both nodes and route to a projected crs
+        # for better accuracy of the sjoin_nearest function to follow
+        nodes = nodes.to_crs(3857)
+        route_points = route_points.to_crs(3857)
+
+        # along the points of the route, find the nodes that are nearest (in order of the route points)
+        route_points_nearest_nodes = route_points.sjoin_nearest(nodes).sort_index()
+        route_nodes = list(
+            route_points_nearest_nodes.drop_duplicates(subset=[node_id_column])[node_id_column]
+        )
+
+        # print(unique_route, route_nodes)
+
+        # record adjacencies from the ordered route nodes list
+        for i in range(len(route_nodes) - 1):
+            current_node_id = route_nodes[i]
+            adjacent_node_id = route_nodes[i + 1]
+
+            if current_node_id not in adjacencies:
+                adjacencies[current_node_id] = []
+            if adjacent_node_id not in adjacencies:
+                adjacencies[adjacent_node_id] = []
+
+            if adjacent_node_id not in adjacencies[current_node_id]:
+                adjacencies[current_node_id].append(adjacent_node_id)
+                total_adjacencies += 1
+            if current_node_id not in adjacencies[adjacent_node_id]:
+                adjacencies[adjacent_node_id].append(current_node_id)
+
+    # print('total connections=', total_adjacencies)
+
+    # Create all NetworkNode objects first, then populate adjacencies after.
+    dataset.network_nodes.all().delete()
+    node_set = node_set.drop_duplicates(subset=[node_id_column])
+    for i, node in node_set.iterrows():
+        properties = node.drop(['geometry', 'colors', node_id_column])
+        properties = properties.replace(numpy.nan, 'None')
+        location = Point(x=node.geometry.x, y=node.geometry.y)
+        NetworkNode(
+            name=node[node_id_column],
+            dataset=dataset,
+            location=location,
+            properties=dict(properties),
+        ).save()
+    for i, node in node_set.iterrows():
+        adjacent_node_ids = adjacencies.get(node[node_id_column])
+        if not adjacent_node_ids:
+            continue
+        node_object = NetworkNode.objects.get(name=node[node_id_column])
+        node_object.adjacent_nodes.set(NetworkNode.objects.filter(name__in=adjacent_node_ids))
+        node_object.save()
+
+
+@shared_task
+def network_gcc(edge_list, exclude_nodes):
+    print({'edge_list': edge_list, 'exclude_nodes': exclude_nodes})

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -10,7 +10,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from uvdat.core.models import City, Dataset
 from uvdat.core.serializers import CitySerializer, DatasetSerializer, NetworkNodeSerializer
-from uvdat.core.tasks import convert_raw_archive
+from uvdat.core.tasks.conversion import convert_raw_archive
 
 TILES_DIR = tempfile.TemporaryDirectory()
 

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -11,6 +11,7 @@ from rest_framework.viewsets import ModelViewSet
 from uvdat.core.models import City, Dataset
 from uvdat.core.serializers import CitySerializer, DatasetSerializer, NetworkNodeSerializer
 from uvdat.core.tasks.conversion import convert_raw_archive
+from uvdat.core.tasks.networks import network_gcc
 
 TILES_DIR = tempfile.TemporaryDirectory()
 
@@ -67,4 +68,26 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
         dataset.processing = True
         dataset.save()
         convert_raw_archive.delay(dataset.id)
-        return Response(DatasetSerializer(dataset).data, status=200)
+        return Response(status=200)
+
+    @action(
+        detail=True,
+        methods=['post'],
+        url_path=r'gcc',
+        url_name='gcc',
+    )
+    def spawn_gcc_task(self, request, **kwargs):
+        dataset = self.get_object()
+        if not dataset.network:
+            return Response('This dataset is not a network dataset.', status=400)
+        exclude_nodes = request.data['exclude_nodes']
+        edge_list = []
+        visited_nodes = []
+        for node in dataset.network_nodes.all():
+            for adj_node in node.adjacent_nodes.all():
+                if adj_node.id not in visited_nodes:
+                    edge_list.append((node.id, adj_node.id))
+            visited_nodes.append(node.id)
+
+        network_gcc.delay(edge_list, exclude_nodes)
+        return Response(status=200)

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -81,13 +81,9 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
         if not dataset.network:
             return Response('This dataset is not a network dataset.', status=400)
         exclude_nodes = request.data['exclude_nodes']
-        edge_list = []
-        visited_nodes = []
+        edge_list = {}
         for node in dataset.network_nodes.all():
-            for adj_node in node.adjacent_nodes.all():
-                if adj_node.id not in visited_nodes:
-                    edge_list.append((node.id, adj_node.id))
-            visited_nodes.append(node.id)
+            edge_list[node.id] = [adj_node.id for adj_node in node.adjacent_nodes.all()]
 
         network_gcc.delay(edge_list, exclude_nodes)
         return Response(status=200)


### PR DESCRIPTION
This PR adds a new celery task called `network_gcc`, which accepts two parameters `edge_list` and `exclude_nodes`. For now, this task is empty except for a print statement. This will be a placeholder for where we will invoke the code from NU.

This PR also adds an endpoint for spawning the new task, and it does a bit of mild refactoring. To avoid overloading the `tasks.py` file, this PR splits the celery tasks into two files: `tasks/conversion.py` and `tasks/networks.py`.

