### PR TITLE
Deactivate nodes

### DIFF
--- a/sample_data/datasets.json
+++ b/sample_data/datasets.json
@@ -104,7 +104,7 @@
         "path": "boston/easternmass.tif",
         "style": {
             "options": {
-                "transparency_threshold": 0,
+                "transparency_threshold": 1,
                 "trim_distribution_percentage": 0.01
             }
         }

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'matplotlib',
         'geojson2vt',
         'geopandas',
+        'networkx',
         'pyshp',
         'rasterio',
         'urllib3==1.26.15',  # compensate for a bug affecting swagger docs page

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -95,5 +95,5 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
                 edge_list[node.id] = sorted(adjacencies)
             visited_nodes.append(node.id)
 
-        network_gcc.delay(edge_list, exclude_nodes)
-        return Response(status=200)
+        gcc = network_gcc(edge_list, exclude_nodes)
+        return Response(gcc, status=200)

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -72,17 +72,19 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
 
     @action(
         detail=True,
-        methods=['post'],
+        methods=['get'],
         url_path=r'gcc',
         url_name='gcc',
     )
-    def spawn_gcc_task(self, request, **kwargs):
+    def get_gcc(self, request, **kwargs):
         dataset = self.get_object()
         if not dataset.network:
             return Response('This dataset is not a network dataset.', status=400)
-        if "exclude_nodes" not in request.data:
+        if "exclude_nodes" not in dict(request.query_params):
             return Response('Please specify a list of nodes to exclude in `exclude_nodes`.')
-        exclude_nodes = request.data['exclude_nodes']
+        exclude_nodes = request.query_params.get('exclude_nodes')
+        exclude_nodes = exclude_nodes.split(',')
+        exclude_nodes = [int(n) for n in exclude_nodes if len(n)]
         edge_list = {}
         visited_nodes = []
         for node in dataset.network_nodes.all():

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -18,3 +18,14 @@ export async function getDatasetNetwork(
 ): Promise<NetworkNode[]> {
   return (await apiClient.get(`datasets/${datasetId}/network`)).data;
 }
+
+export async function getNetworkGCC(
+  datasetId: number,
+  exclude_nodes: number[]
+): Promise<NetworkNode[]> {
+  return (
+    await apiClient.get(
+      `datasets/${datasetId}/gcc?exclude_nodes=${exclude_nodes.toString()}`
+    )
+  ).data;
+}

--- a/web/src/components/DrawerContents.vue
+++ b/web/src/components/DrawerContents.vue
@@ -50,7 +50,10 @@ export default {
       );
       if (enable) {
         selectedDatasets.value = [dataset, ...selectedDatasets.value];
-      } else if (dataset.id === currentDataset.value.id) {
+      } else if (
+        currentDataset.value &&
+        dataset.id === currentDataset.value.id
+      ) {
         currentDataset.value = undefined;
       }
       updateActiveDatasets();

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -35,6 +35,7 @@ export default {
         currentDataset.value?.style?.data_range?.map((v) => Math.round(v)) ||
         undefined;
       colormapRange.value = datasetRange.value;
+      deactivatedNodes.value = [];
     }
 
     function updateLayerOpacity() {
@@ -79,19 +80,18 @@ export default {
           .getArray()
           .forEach((layer) => {
             const layerDatasetId = layer.getProperties().datasetId;
-            const layerIsNetwork = layer.getProperties().network;
-            if (layerDatasetId === currentDataset.value.id) {
-              if (layerIsNetwork) {
-                layer.setVisible(networkVis.value !== undefined);
+            if (layer.getProperties().network) {
+              layer.setVisible(networkVis.value.id === layerDatasetId);
+              if (layerDatasetId === currentDataset.value.id) {
                 createNetworkLayer = false;
-              } else {
-                layer.setVisible(networkVis.value === undefined);
               }
+            } else {
+              layer.setVisible(networkVis.value.id !== layerDatasetId);
             }
           });
         if (createNetworkLayer) {
           getDatasetNetwork(currentDataset.value.id).then((nodes) => {
-            if (nodes.length) {
+            if (nodes.length && networkVis.value) {
               networkVis.value.nodes = nodes;
               addNetworkLayerToMap(currentDataset.value, nodes);
             }

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -1,5 +1,5 @@
 <script>
-import { currentDataset, map } from "@/store";
+import { currentDataset, map, rasterTooltip } from "@/store";
 import { onMounted, ref, watch } from "vue";
 import {
   rasterColormaps,
@@ -118,9 +118,10 @@ export default {
       colormap,
       datasetRange,
       colormapRange,
-      showConfirmConvert,
+      rasterTooltip,
       networkVisMode,
       toggleNetworkVisMode,
+      showConfirmConvert,
       runConversion,
     };
   },
@@ -190,6 +191,11 @@ export default {
             />
           </template>
         </v-range-slider>
+        <v-switch
+          v-model="rasterTooltip"
+          :value="currentDataset.id"
+          label="Show value tooltip"
+        />
       </div>
 
       <div v-if="currentDataset.network">

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -4,6 +4,7 @@ import {
   rasterColormaps,
   addDatasetLayerToMap,
   addNetworkLayerToMap,
+  toggleNodeActive,
 } from "../utils";
 import { convertDataset, getDatasetNetwork } from "../api/rest";
 import {
@@ -72,6 +73,16 @@ export default {
       }
     }
 
+    function updateColormapMin(min) {
+      colormapRange.value[0] = min;
+      updateCurrentDatasetLayer();
+    }
+
+    function updateColormapMax(max) {
+      colormapRange.value[1] = max;
+      updateCurrentDatasetLayer();
+    }
+
     function toggleNetworkVis() {
       if (currentDataset.value) {
         let createNetworkLayer = true;
@@ -125,9 +136,12 @@ export default {
       colormap,
       datasetRange,
       colormapRange,
+      updateColormapMin,
+      updateColormapMax,
       rasterTooltip,
       networkVis,
       toggleNetworkVis,
+      toggleNodeActive,
       deactivatedNodes,
       showConfirmConvert,
       runConversion,
@@ -184,7 +198,7 @@ export default {
               dense
               type="number"
               style="width: 60px"
-              @change="$set(colormapRange, 0, $event)"
+              @change="(e) => updateColormapMin(e.target.value)"
             />
           </template>
           <template v-slot:append>
@@ -195,7 +209,7 @@ export default {
               dense
               type="number"
               style="width: 60px"
-              @change="$set(colormapRange, 1, $event)"
+              @change="(e) => updateColormapMax(e.target.value)"
             />
           </template>
         </v-range-slider>
@@ -226,6 +240,13 @@ export default {
               :key="deactivated"
             >
               {{ networkVis.nodes.find((n) => n.id === deactivated)?.name }}
+              <v-btn
+                size="small"
+                style="float: right"
+                @click="(e) => toggleNodeActive(deactivated)"
+              >
+                Activate
+              </v-btn>
             </v-expansion-panel-text>
           </v-expansion-panel>
         </v-expansion-panels>
@@ -277,5 +298,8 @@ export default {
   bottom: 0;
   right: 0;
   width: 100%;
+}
+.v-btn__content {
+  white-space: inherit !important;
 }
 </style>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -16,6 +16,7 @@ export const currentDataset = ref<Dataset>();
 
 export const map = ref();
 export const mapLayers = ref();
+export const rasterTooltip = ref();
 
 export function loadCities() {
   getCities().then((data) => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -17,6 +17,8 @@ export const currentDataset = ref<Dataset>();
 export const map = ref();
 export const mapLayers = ref();
 export const rasterTooltip = ref();
+export const networkVis = ref();
+export const deactivatedNodes = ref([]);
 
 export function loadCities() {
   getCities().then((data) => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -17,8 +17,10 @@ export const currentDataset = ref<Dataset>();
 export const map = ref();
 export const mapLayers = ref();
 export const rasterTooltip = ref();
+
 export const networkVis = ref();
 export const deactivatedNodes = ref([]);
+export const currentNetworkGCC = ref();
 
 export function loadCities() {
   getCities().then((data) => {

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -9,10 +9,16 @@ import { Fill, Stroke, Circle, Style } from "ol/style.js";
 import { Feature } from "ol";
 import { LineString, Point } from "ol/geom";
 import { fromLonLat } from "ol/proj";
+import axios from "axios";
 
 import { baseURL } from "@/api/auth";
-import { map, currentDataset, rasterTooltip } from "@/store";
-import axios from "axios";
+import {
+  map,
+  currentDataset,
+  rasterTooltip,
+  networkVis,
+  deactivatedNodes,
+} from "@/store";
 
 export const rasterColormaps = [
   "terrain",
@@ -127,6 +133,26 @@ export function addDatasetLayerToMap(dataset, zIndex) {
   }
 }
 
+function getNetworkFeatureStyle(alpha = "ff") {
+  const fill = new Fill({
+    color: `#ffffff${alpha}`,
+  });
+  const stroke = new Stroke({
+    color: `#000000${alpha}`,
+    width: 3,
+  });
+  const style = new Style({
+    image: new Circle({
+      fill: fill,
+      stroke: stroke,
+      radius: 7,
+    }),
+    fill: fill,
+    stroke: stroke,
+  });
+  return style;
+}
+
 export function addNetworkLayerToMap(dataset, nodes) {
   const source = new VectorSource();
   const features = [];
@@ -136,6 +162,8 @@ export function addNetworkLayerToMap(dataset, nodes) {
       new Feature(
         Object.assign(node.properties, {
           name: node.name,
+          id: node.id,
+          node: true,
           geometry: new Point(fromLonLat(node.location.toReversed())),
         })
       )
@@ -145,6 +173,8 @@ export function addNetworkLayerToMap(dataset, nodes) {
         const adjNode = nodes.find((n) => n.id === adjId);
         features.push(
           new Feature({
+            connects: [node.id, adjId],
+            edge: true,
             geometry: new LineString([
               fromLonLat(node.location.toReversed()),
               fromLonLat(adjNode.location.toReversed()),
@@ -157,29 +187,13 @@ export function addNetworkLayerToMap(dataset, nodes) {
   });
   source.addFeatures(features);
 
-  const fill = new Fill({
-    color: "#ffffffff",
-  });
-  const stroke = new Stroke({
-    color: "#000000ff",
-    width: 3,
-  });
-  const style = new Style({
-    image: new Circle({
-      fill: fill,
-      stroke: stroke,
-      radius: 7,
-    }),
-    fill: fill,
-    stroke: stroke,
-  });
   const layer = new VectorLayer({
     properties: {
       datasetId: dataset.id,
       network: true,
     },
+    style: getNetworkFeatureStyle(),
     source,
-    style,
   });
   map.value.addLayer(layer);
 }
@@ -191,17 +205,38 @@ export function displayFeatureTooltip(evt, tooltip, overlay) {
     return feature;
   });
   tooltip.value.style.display = feature ? "" : "none";
+  tooltip.value.innerHTML = "";
   if (feature) {
     const properties = Object.fromEntries(
       Object.entries(feature.values_).filter(([k, v]) => k && v)
     );
-    ["colors", "geometry", "type"].forEach((prop) => delete properties[prop]);
-    const prettyString = JSON.stringify(properties)
+    ["colors", "geometry", "type", "id", "node", "edge"].forEach(
+      (prop) => delete properties[prop]
+    );
+    let prettyString = JSON.stringify(properties)
       .replaceAll('"', "")
-      .replaceAll(",", "\n")
       .replaceAll("{", "")
-      .replaceAll("}", "");
-    tooltip.value.innerHTML = prettyString;
+      .replaceAll("}", "")
+      .replaceAll(",", "<br>");
+    prettyString += "<br>";
+    const tooltipDiv = document.createElement("div");
+    tooltipDiv.innerHTML = prettyString;
+    const nodeId = feature?.values_?.id;
+    if (networkVis.value && nodeId) {
+      const deactivateButton = document.createElement("button");
+      if (deactivatedNodes.value.includes(nodeId)) {
+        deactivateButton.innerHTML = "Reactivate Node";
+      } else {
+        deactivateButton.innerHTML = "Deactivate Node";
+      }
+      deactivateButton.onclick = function () {
+        toggleNodeActive(nodeId, deactivateButton);
+      };
+      deactivateButton.classList = "v-btn v-btn--variant-outlined pa-2";
+      tooltipDiv.appendChild(deactivateButton);
+    }
+
+    tooltip.value.appendChild(tooltipDiv);
     // make sure the tooltip isn't cut off
     const mapCenter = map.value.get("view").get("center");
     const viewPortSize = map.value.get("view").viewportSize_;
@@ -221,11 +256,12 @@ var rasterTooltipDataCache = {};
 
 export function displayRasterTooltip(evt, tooltip, overlay) {
   if (!currentDataset.value) return;
+  // console.log("TODO: raster tooltip", tooltip, overlay);
   var pixel = evt.pixel;
   var data = undefined;
   if (rasterTooltip.value && rasterTooltipDataCache[rasterTooltip.value]) {
     data = rasterTooltipDataCache[rasterTooltip.value];
-    console.log("pixel=", pixel, "data=", data);
+    // console.log("pixel=", pixel, "data=", data);
   } else {
     var dataFile = currentDataset.value.raster_file;
     if (dataFile) {
@@ -238,4 +274,46 @@ export function displayRasterTooltip(evt, tooltip, overlay) {
         });
     }
   }
+}
+
+function toggleNodeActive(nodeId, button) {
+  if (deactivatedNodes.value.includes(nodeId)) {
+    deactivatedNodes.value = deactivatedNodes.value.filter((n) => n !== nodeId);
+    button.innerHTML = "Deactivate Node";
+  } else {
+    deactivatedNodes.value.push(nodeId);
+    button.innerHTML = "Reactivate Node";
+  }
+
+  map.value
+    .getLayers()
+    .getArray()
+    .forEach((layer) => {
+      const layerIsNetwork = layer.getProperties().network;
+      if (layerIsNetwork) {
+        const source = layer.getSource();
+        source.getFeatures().forEach((feature) => {
+          let featureDeactivated = false;
+          const featureProperties = feature.values_;
+          if (
+            featureProperties.node &&
+            featureProperties.id &&
+            deactivatedNodes.value.includes(featureProperties.id)
+          ) {
+            featureDeactivated = true;
+          } else if (
+            featureProperties.edge &&
+            featureProperties.connects &&
+            featureProperties.connects.some((nId) =>
+              deactivatedNodes.value.includes(nId)
+            )
+          ) {
+            featureDeactivated = true;
+          }
+          if (featureDeactivated) {
+            feature.setStyle(getNetworkFeatureStyle("44"));
+          }
+        });
+      }
+    });
 }

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -312,6 +312,8 @@ function toggleNodeActive(nodeId, button) {
           }
           if (featureDeactivated) {
             feature.setStyle(getNetworkFeatureStyle("44"));
+          } else {
+            feature.setStyle(null); // will default to layer style
           }
         });
       }


### PR DESCRIPTION
This PR incorporates @johnkit's `compute_gcc` function. These changes allow the user to select nodes and mark them as deactivated. When the list of deactivated nodes changes, the GCC is recomputed and shown to the user by highlighting features included in the GCC.

https://github.com/OpenGeoscience/uvdat/assets/44912689/76c50232-fa29-40d2-8550-deb874682d90

