### PR TITLE
UI updates

### DIFF
--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -1,9 +1,12 @@
 import json
+import ijson
 import tempfile
+import large_image
+from pathlib import Path
 
 from django.http import HttpResponse
 from django_large_image.rest import LargeImageFileDetailMixin
-import ijson
+
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -12,8 +15,6 @@ from uvdat.core.models import City, Dataset
 from uvdat.core.serializers import CitySerializer, DatasetSerializer, NetworkNodeSerializer
 from uvdat.core.tasks.conversion import convert_raw_archive
 from uvdat.core.tasks.networks import network_gcc
-
-TILES_DIR = tempfile.TemporaryDirectory()
 
 
 class CityViewSet(ModelViewSet):
@@ -41,6 +42,33 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
                 return HttpResponse(json.dumps(tile.__next__()), status=200)
             except StopIteration:
                 return HttpResponse(status=404)
+
+    @action(
+        detail=True,
+        methods=['get'],
+        url_path=r'raster-data/(?P<resolution>[\d*\.?\d*]+)',
+        url_name='raster_data',
+    )
+    def get_raster_data(self, request, resolution: str = '1', **kwargs):
+        dataset = self.get_object()
+        if dataset.raster_file:
+            with tempfile.TemporaryDirectory() as tmp:
+                raster_path = Path(tmp, 'raster')
+                with open(raster_path, 'wb') as raster_file:
+                    raster_file.write(dataset.raster_file.read())
+                source = large_image.open(raster_path)
+                data, data_format = source.getRegion(format='numpy')
+                data = data[:, :, 0]
+                if resolution:
+                    resolution = float(resolution)
+                    if resolution != 1.0:
+                        step = int(1 / resolution)
+                        print(step)
+                        data = data[::step][::step]
+                print(data.shape)
+                return HttpResponse(json.dumps(data.tolist()), status=200)
+        else:
+            return HttpResponse('Dataset has no raster file.', status=400)
 
     @action(
         detail=True,

--- a/uvdat/core/views.py
+++ b/uvdat/core/views.py
@@ -63,9 +63,7 @@ class DatasetViewSet(ModelViewSet, LargeImageFileDetailMixin):
                     resolution = float(resolution)
                     if resolution != 1.0:
                         step = int(1 / resolution)
-                        print(step)
                         data = data[::step][::step]
-                print(data.shape)
                 return HttpResponse(json.dumps(data.tolist()), status=200)
         else:
             return HttpResponse('Dataset has no raster file.', status=400)

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -69,6 +69,7 @@ export default defineComponent({
       :model-value="currentDataset !== undefined"
       permanent
       width="250"
+      location="right"
       class="main-area drawer options-drawer"
     >
       <OptionsDrawerContents />
@@ -102,7 +103,8 @@ export default defineComponent({
   width: calc(100% - 250px);
 }
 .shifted-2 {
-  left: 500px;
+  left: 250px;
+  right: 250px;
   width: calc(100% - 500px);
 }
 </style>

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./auth";
-import { City, Dataset, NetworkNode } from "@/types";
+import { City, Dataset, NetworkNode, RasterData } from "@/types";
 
 export async function getCities(): Promise<City[]> {
   return (await apiClient.get("cities")).data.results;
@@ -28,4 +28,18 @@ export async function getNetworkGCC(
       `datasets/${datasetId}/gcc?exclude_nodes=${exclude_nodes.toString()}`
     )
   ).data;
+}
+
+export async function getRasterData(datasetId: number): Promise<RasterData> {
+  const resolution = 0.1;
+  const data = (
+    await apiClient.get(`datasets/${datasetId}/raster-data/${resolution}`)
+  ).data;
+  const { sourceBounds } = (
+    await apiClient.get(`datasets/${datasetId}/info/metadata`)
+  ).data;
+  return {
+    data,
+    sourceBounds,
+  };
 }

--- a/web/src/components/DrawerContents.vue
+++ b/web/src/components/DrawerContents.vue
@@ -143,6 +143,13 @@ export default {
                   <v-tooltip activator="parent" location="end" max-width="300">
                     {{ dataset.description }}
                   </v-tooltip>
+                  <v-icon
+                    size="small"
+                    class="expand-icon"
+                    @click.prevent="expandOptionsPanel(dataset)"
+                  >
+                    mdi-cog
+                  </v-icon>
                 </template>
               </v-checkbox>
             </v-expansion-panel-text>
@@ -166,7 +173,7 @@ export default {
                 class="expand-icon"
                 @click="expandOptionsPanel(element)"
               >
-                mdi-arrow-expand-right
+                mdi-cog
               </v-icon>
               {{ element.name }}
             </v-card>

--- a/web/src/components/DrawerContents.vue
+++ b/web/src/components/DrawerContents.vue
@@ -19,13 +19,15 @@ export default {
           (rv[x[groupKey]] = rv[x[groupKey]] || []).push(x);
           return rv;
         }, {})
-      ).map(([name, children], id) => {
-        return {
-          id,
-          name,
-          children,
-        };
-      });
+      )
+        .map(([name, children], id) => {
+          return {
+            id,
+            name,
+            children,
+          };
+        })
+        .sort((a, b) => a.name > b.name);
     });
     const activeLayerTableHeaders = [{ text: "Name", value: "name" }];
 
@@ -144,6 +146,7 @@ export default {
                     {{ dataset.description }}
                   </v-tooltip>
                   <v-icon
+                    v-show="selectedDatasets.includes(dataset)"
                     size="small"
                     class="expand-icon"
                     @click.prevent="expandOptionsPanel(dataset)"

--- a/web/src/components/DrawerContents.vue
+++ b/web/src/components/DrawerContents.vue
@@ -1,7 +1,7 @@
 <script>
 import draggable from "vuedraggable";
 import { currentCity, currentDataset, map } from "@/store";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import { addDatasetLayerToMap } from "@/utils.js";
 
 export default {
@@ -11,6 +11,22 @@ export default {
   setup() {
     const selectedDatasets = ref([]);
     const openPanels = ref([0]);
+    const openCategories = ref([0]);
+    const availableLayerTree = computed(() => {
+      const groupKey = "category";
+      return Object.entries(
+        currentCity.value.datasets.reduce(function (rv, x) {
+          (rv[x[groupKey]] = rv[x[groupKey]] || []).push(x);
+          return rv;
+        }, {})
+      ).map(([name, children], id) => {
+        return {
+          id,
+          name,
+          children,
+        };
+      });
+    });
     const activeLayerTableHeaders = [{ text: "Name", value: "name" }];
 
     function updateActiveDatasets() {
@@ -84,8 +100,10 @@ export default {
       selectedDatasets,
       currentCity,
       openPanels,
+      openCategories,
       toggleDataset,
       updateActiveDatasets,
+      availableLayerTree,
       activeLayerTableHeaders,
       reorderLayers,
       expandOptionsPanel,
@@ -98,24 +116,38 @@ export default {
   <v-expansion-panels multiple variant="accordion" v-model="openPanels">
     <v-expansion-panel title="Available Layers">
       <v-expansion-panel-text>
-        <v-checkbox
-          v-for="dataset in currentCity.datasets"
-          :model-value="selectedDatasets.includes(dataset)"
-          :key="dataset.name"
-          :label="dataset.name"
-          :disabled="dataset.processing"
-          @change="() => toggleDataset(dataset)"
-          density="compact"
-          hide-details
+        <v-expansion-panels
+          multiple
+          variant="accordion"
+          v-model="openCategories"
         >
-          <template v-slot:label>
-            {{ dataset.name }}
-            {{ dataset.processing ? "(processing)" : "" }}
-            <v-tooltip activator="parent" location="end" max-width="300">
-              {{ dataset.description }}
-            </v-tooltip>
-          </template>
-        </v-checkbox>
+          <v-expansion-panel
+            v-for="category in availableLayerTree"
+            :title="category.name"
+            :key="category.id"
+          >
+            <v-expansion-panel-text>
+              <v-checkbox
+                v-for="dataset in category.children"
+                :model-value="selectedDatasets.includes(dataset)"
+                :key="dataset.name"
+                :label="dataset.name"
+                :disabled="dataset.processing"
+                @change="() => toggleDataset(dataset)"
+                density="compact"
+                hide-details
+              >
+                <template v-slot:label>
+                  {{ dataset.name }}
+                  {{ dataset.processing ? "(processing)" : "" }}
+                  <v-tooltip activator="parent" location="end" max-width="300">
+                    {{ dataset.description }}
+                  </v-tooltip>
+                </template>
+              </v-checkbox>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
       </v-expansion-panel-text>
     </v-expansion-panel>
 

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -177,7 +177,6 @@ export default {
           dense
           :items="rasterColormaps"
           label="Color map"
-          @input="switchColormap"
         />
         <v-card-text v-if="colormapRange" class="pa-0">
           Color map range

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -42,3 +42,13 @@ export interface NetworkNode {
   dataset: number;
   adjacent_nodes: number[];
 }
+
+export interface RasterData {
+  sourceBounds: {
+    xmax: number;
+    xmin: number;
+    ymax: number;
+    ymin: number;
+  };
+  data: number[][];
+}


### PR DESCRIPTION
This PR makes the following UI changes:

- Organize available layers by category, using expansion panels to show/hide groups
- Move the options panel to the righthand side of the map to create more visual separation between the two panels
- Use a gear icon to open the options panel, shown in both the active layers list and the available layers list (if a layer is active)
- Add a toggle to the options panel for any raster dataset "Show raster tooltip". When enabled, mousing over the raster will give an approximate value. Values are approximate because the data is received at a 1/10 resolution to reduce load time, and because mouse position to array index conversion is done by proportion of coordinates.
![image](https://github.com/OpenGeoscience/uvdat/assets/44912689/b635f464-3a37-4034-adde-9d12406713ff)
