### PR TITLE
Layer Visibility Logic

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -8,7 +8,9 @@ import {
   loading,
   loadCities,
   activeChart,
+  showMapBaseLayer,
 } from "./store";
+import { updateVisibleLayers } from "./utils";
 import OpenLayersMap from "./components/OpenLayersMap.vue";
 import MainDrawerContents from "./components/MainDrawerContents.vue";
 import OptionsDrawerContents from "./components/OptionsDrawerContents.vue";
@@ -35,6 +37,8 @@ export default defineComponent({
       loading,
       currentError,
       activeChart,
+      showMapBaseLayer,
+      updateVisibleLayers,
     };
   },
 });
@@ -65,6 +69,14 @@ export default defineComponent({
           :style="{ marginTop: '15px' }"
         />
       </v-list-item>
+      <v-checkbox
+        v-model="showMapBaseLayer"
+        @change="updateVisibleLayers"
+        true-icon="mdi-map-check"
+        false-icon="mdi-map-outline"
+        style="max-width: 50px"
+        hide-details
+      />
     </v-app-bar>
     <v-navigation-drawer
       v-if="currentCity"

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -65,7 +65,7 @@ export default {
           .forEach((layer) => {
             const layerDatasetId = layer.getProperties().datasetId;
             if (layerDatasetId === currentDataset.value.id) {
-              zIndex = layer.zIndex;
+              zIndex = layer.getZIndex();
               map.value.removeLayer(layer);
             }
           });

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -5,6 +5,7 @@ import {
   addDatasetLayerToMap,
   addNetworkLayerToMap,
   toggleNodeActive,
+  updateVisibleLayers,
 } from "../utils";
 import { convertDataset, getDatasetNetwork } from "../api/rest";
 import {
@@ -84,24 +85,13 @@ export default {
 
     function toggleNetworkVis() {
       if (currentDataset.value) {
-        let createNetworkLayer = true;
-        map.value
-          .getLayers()
-          .getArray()
-          .forEach((layer) => {
-            const layerDatasetId = layer.getProperties().datasetId;
-            if (layer.getProperties().network) {
-              layer.setVisible(networkVis.value.id === layerDatasetId);
-              if (layerDatasetId === currentDataset.value.id) {
-                createNetworkLayer = false;
-              }
-            } else {
-              layer.setVisible(
-                !layerDatasetId || networkVis.value.id !== layerDatasetId
-              );
-            }
-          });
-        if (createNetworkLayer) {
+        const updated = updateVisibleLayers();
+        if (
+          !updated.shown.some(
+            (l) => l.getProperties().datasetId === networkVis.value.id
+          )
+        ) {
+          // no existing one shown, create a new network layer
           getDatasetNetwork(currentDataset.value.id).then((nodes) => {
             if (nodes.length && networkVis.value) {
               networkVis.value.nodes = nodes;

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -55,7 +55,6 @@ export default {
 
     function updateCurrentDatasetLayer() {
       if (currentDataset.value) {
-        let zIndex = 0;
         currentDataset.value.style.opacity = opacity.value;
         currentDataset.value.style.colormap = colormap.value;
         currentDataset.value.style.colormap_range = colormapRange.value;
@@ -64,12 +63,15 @@ export default {
           .getArray()
           .forEach((layer) => {
             const layerDatasetId = layer.getProperties().datasetId;
-            if (layerDatasetId === currentDataset.value.id) {
-              zIndex = layer.getZIndex();
+            const layerNetwork = layer.getProperties().network;
+            if (
+              layerDatasetId === currentDataset.value.id &&
+              networkVis.value.id === layerNetwork
+            ) {
               map.value.removeLayer(layer);
+              addDatasetLayerToMap(currentDataset.value, layer.getZIndex());
             }
           });
-        addDatasetLayerToMap(currentDataset.value, zIndex);
       }
     }
 

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -66,7 +66,7 @@ export default {
             const layerNetwork = layer.getProperties().network;
             if (
               layerDatasetId === currentDataset.value.id &&
-              networkVis.value.id === layerNetwork
+              networkVis.value?.id === layerNetwork
             ) {
               map.value.removeLayer(layer);
               addDatasetLayerToMap(currentDataset.value, layer.getZIndex());

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -66,7 +66,9 @@ export default {
             const layerNetwork = layer.getProperties().network;
             if (
               layerDatasetId === currentDataset.value.id &&
-              networkVis.value?.id === layerNetwork
+              (!networkVis.value ||
+                !layerNetwork ||
+                networkVis.value?.id === layerNetwork)
             ) {
               map.value.removeLayer(layer);
               addDatasetLayerToMap(currentDataset.value, layer.getZIndex());

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -17,6 +17,7 @@ export const selectedDatasetIds = ref<number[]>([]);
 
 export const map = ref();
 export const mapLayers = ref();
+export const showMapBaseLayer = ref(true);
 export const rasterTooltip = ref();
 export const activeChart = ref();
 export const availableCharts = ref();

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -84,3 +84,9 @@ export function pollForProcessingDataset(datasetId: number) {
     }
   }, 10000);
 }
+
+export function currentDatasetChanged() {
+  rasterTooltip.value = undefined;
+}
+
+watch(currentDataset, currentDatasetChanged);

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -13,6 +13,7 @@ export const currentError = ref<string>();
 export const cities = ref<City[]>([]);
 export const currentCity = ref<City>();
 export const currentDataset = ref<Dataset>();
+export const selectedDatasetIds = ref<number[]>([]);
 
 export const map = ref();
 export const mapLayers = ref();

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -223,7 +223,6 @@ export function addDatasetLayerToMap(dataset, zIndex) {
         }),
       });
     }
-    console.log("add", layer);
     // Add to map
     map.value.addLayer(layer);
   }

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -493,7 +493,7 @@ export function toggleNodeActive(nodeId, button = null) {
     // update chart
     getCityCharts(currentCity.value.id).then((charts) => {
       availableCharts.value = charts;
-      if (activeChart) {
+      if (activeChart.value) {
         activeChart.value = charts.find((c) => c.id === activeChart.value.id);
       }
     });

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -50,7 +50,7 @@ export const rasterColormaps = [
 var rasterTooltipDataCache = {};
 
 export function updateVisibleLayers() {
-  const changes = {
+  const layerState = {
     shown: [],
     hidden: [],
   };
@@ -61,7 +61,7 @@ export function updateVisibleLayers() {
       let layerEnabled = selectedDatasetIds.value.includes(layerDatasetId);
 
       if (!layerDatasetId) {
-        // map layer does not have dataset id
+        // map base layer does not have dataset id
         layerEnabled = showMapBaseLayer.value;
       }
 
@@ -74,28 +74,21 @@ export function updateVisibleLayers() {
       }
 
       if (layerEnabled) {
-        if (!layer.getVisible()) {
-          layer.setVisible(true);
-          changes.shown.push(layer);
-        } else {
-          // already visible, reorder z index
-          const layerIndex = selectedDatasetIds.value.findIndex(
-            (id) => id === layerDatasetId
-          );
-          layer.setZIndex(
-            layerDatasetId ? selectedDatasetIds.value.length - layerIndex : 0
-          );
-        }
+        layer.setVisible(true);
+        layerState.shown.push(layer);
+        const layerIndex = selectedDatasetIds.value.findIndex(
+          (id) => id === layerDatasetId
+        );
+        layer.setZIndex(
+          layerDatasetId ? selectedDatasetIds.value.length - layerIndex : 0
+        );
       } else {
-        if (layer.getVisible()) {
-          layer.setVisible(false);
-          changes.hidden.push(layer);
-        }
+        layer.setVisible(false);
+        layerState.hidden.push(layer);
       }
     });
   }
-  console.log(changes);
-  return changes;
+  return layerState;
 }
 
 export function cacheRasterData(datasetId) {

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -14,6 +14,7 @@ import { baseURL } from "@/api/auth";
 import { getNetworkGCC, getCityCharts, getRasterData } from "@/api/rest";
 import {
   map,
+  showMapBaseLayer,
   currentCity,
   selectedDatasetIds,
   rasterTooltip,
@@ -61,7 +62,7 @@ export function updateVisibleLayers() {
 
       if (!layerDatasetId) {
         // map layer does not have dataset id
-        layerEnabled = true;
+        layerEnabled = showMapBaseLayer.value;
       }
 
       if (networkVis.value) {

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -67,7 +67,7 @@ export function updateVisibleLayers() {
 
       if (networkVis.value) {
         if (layerDatasetId === networkVis.value.id) {
-          layerEnabled = layer.getProperties().network;
+          layerEnabled = layerEnabled && layer.getProperties().network;
         }
       } else if (layer.getProperties().network) {
         layerEnabled = false;


### PR DESCRIPTION
This PR is intended to fix any unexpected behavior we found with the map layers. This includes the following:

- [x] Prevent disabled layers from turning back on when a network layer is toggled
- [x] Prevent layer reordering when changing which Dataset is open in the right-hand Options Panel
- [x] Clear raster tooltip when a raster Dataset is not open in the Options Panel; the raster tooltip was overriding normal tooltip behavior and preventing the user from selecting a network node

Additionally, a new layer visibility feature was added:

- [x] A map button now appears in the top-right corner to toggle the visibility of the map layer.