### PR TITLE
Add flood datasets

### DIFF
--- a/dev/.env.docker-compose
+++ b/dev/.env.docker-compose
@@ -1,3 +1,4 @@
+OGR_GEOJSON_MAX_OBJ_SIZE=500MB
 DJANGO_CONFIGURATION=DevelopmentConfiguration
 DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
 DJANGO_CELERY_BROKER_URL=amqp://rabbitmq:5672/

--- a/dev/.env.docker-compose-native
+++ b/dev/.env.docker-compose-native
@@ -1,3 +1,4 @@
+OGR_GEOJSON_MAX_OBJ_SIZE=500MB
 DJANGO_CONFIGURATION=DevelopmentConfiguration
 DJANGO_DATABASE_URL=postgres://postgres:postgres@localhost:5432/django
 DJANGO_CELERY_BROKER_URL=amqp://localhost:5672/

--- a/sample_data/datasets.json
+++ b/sample_data/datasets.json
@@ -130,6 +130,159 @@
         }
     },
     {
+        "name": "9-inch Sea Level Rise",
+        "description": "From Analyze Boston; 9 inches of sea level rise is expected across emissions scenarios as likely to occur as early as the 2030s.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f8743d6725af35134c1479/download",
+        "path": "boston/9in_rise.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "9-inch 10-year Flood",
+        "description": "From Analyze Boston; a 9-inch flood event that has a 1 in 10 chance of occurring in any given year.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f87ba86725af35134c1485/download",
+        "path": "boston/9in_10yr_flood.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "9-inch 100-year Flood",
+        "description": "From Analyze Boston; a 9-inch flood event that has a 1 in 100 chance of occurring in any given year.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f87bc16725af35134c1488/download",
+        "path": "boston/9in_100yr_flood.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "21-inch Sea Level Rise",
+        "description": "From Analyze Boston; 21 inches of sea level rise is expected consistently across emissions scenarios by the end of the 2050s.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f874486725af35134c147c/download",
+        "path": "boston/21in_rise.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "21-inch 10-year Flood",
+        "description": "From Analyze Boston; a 21-inch flood event that has a 1 in 10 chance of occurring in any given year.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f87bd56725af35134c148b/download",
+        "path": "boston/21in_10yr_flood.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "21-inch 100-year Flood",
+        "description": "From Analyze Boston; a 21-inch flood event that has a 1 in 100 chance of occurring in any given year.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f87be96725af35134c148e/download",
+        "path": "boston/21in_100yr_flood.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "36-inch Sea Level Rise",
+        "description": "From Analyze Boston; 36 inches of sea level rise has a 50% chance of occurring by the end of the century according to emissions scenarios.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f874566725af35134c147f/download",
+        "path": "boston/36in_rise.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "36-inch 10-year Flood",
+        "description": "From Analyze Boston; a 36-inch flood event that has a 1 in 10 chance of occurring in any given year.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f87bfd6725af35134c1491/download",
+        "path": "boston/36in_10yr_flood.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
+        "name": "36-inch 100-year Flood",
+        "description": "From Analyze Boston; a 36-inch flood event that has a 1 in 100 chance of occurring in any given year.",
+        "category": "flood",
+        "city": "Boston, MA",
+        "raw_data_type": "geojson",
+        "url": "https://data.kitware.com/api/v1/item/64f87c496725af35134c1494/download",
+        "path": "boston/36in_100yr_flood.geojson",
+        "style": {
+            "options": {
+                "outline": "white",
+                "palette": [
+                    "blue"
+                ]
+            }
+        }
+    },
+    {
         "name": "DC Metro",
         "description": "DC Metro Lines and Stations",
         "category": "transportation",

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -149,6 +149,7 @@ export function addDatasetLayerToMap(dataset, zIndex) {
   if (dataset.processing) {
     return;
   }
+  let layer = undefined;
 
   // Add raster data
   if (dataset.raster_file) {
@@ -171,27 +172,23 @@ export function addDatasetLayerToMap(dataset, zIndex) {
       .map((key) => key + "=" + tileParams[key])
       .join("&");
 
-    map.value.addLayer(
-      new TileLayer({
-        properties: {
-          datasetId: dataset.id,
-          dataset,
-        },
-        source: new XYZSource({
-          url: `${baseURL}datasets/${dataset.id}/tiles/{z}/{x}/{y}.png/?${tileParamString}`,
-        }),
-        opacity: dataset.style?.opacity || 1,
-        zIndex,
-      })
-    );
+    layer = new TileLayer({
+      properties: {
+        datasetId: dataset.id,
+        dataset,
+      },
+      source: new XYZSource({
+        url: `${baseURL}datasets/${dataset.id}/tiles/{z}/{x}/{y}.png/?${tileParamString}`,
+      }),
+      opacity: dataset.style?.opacity || 1,
+      zIndex,
+    });
     cacheRasterData(dataset.id);
-    return;
   }
 
-  // Add GeoJSON data
-  if (dataset.geodata_file) {
-    // Default to vector tile layer
-    let layer = new VectorTileLayer({
+  // Use tiled GeoJSON if it exists
+  else if (dataset.tiled_geo_file) {
+    layer = new VectorTileLayer({
       source: new VectorTileSource({
         format: new GeoJSON(),
         url: `${baseURL}datasets/${dataset.id}/vector-tiles/{z}/{x}/{y}/`,
@@ -231,6 +228,33 @@ export function addDatasetLayerToMap(dataset, zIndex) {
     // Add to map
     map.value.addLayer(layer);
   }
+
+  // Default to vector layer
+  else {
+    let dataURL = dataset.geodata_file;
+    if (dataset.category === "region") {
+      dataURL = `${baseURL}datasets/${dataset.id}/regions`;
+    }
+    layer = new VectorLayer({
+      properties: {
+        datasetId: dataset.id,
+        dataset,
+      },
+      zIndex,
+      style: (feature) =>
+        createStyle({
+          type: feature.getGeometry().getType(),
+          colors: feature.getProperties().colors,
+        }),
+      source: new VectorSource({
+        format: new GeoJSON(),
+        url: dataURL,
+      }),
+    });
+  }
+
+  // Add to map
+  map.value.addLayer(layer);
 }
 
 function getNetworkFeatureStyle(alpha = "ff", highlight = false) {

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -187,7 +187,7 @@ export function addDatasetLayerToMap(dataset, zIndex) {
   }
 
   // Use tiled GeoJSON if it exists
-  else if (dataset.tiled_geo_file) {
+  else if (dataset.vector_tiles_file) {
     layer = new VectorTileLayer({
       source: new VectorTileSource({
         format: new GeoJSON(),


### PR DESCRIPTION
This PR adds 9 datasets to `datasets.json`. Running `python manage.py populate` in the Django container will make these datasets available on the map. 

- 9 inch sea level rise
- 9 inch 10 year flood
- 9 inch 100 year flood
- 21 inch sea level rise
- 21 inch 10 year flood
- 21 inch 100 year flood
- 36 inch sea level rise
- 36 inch 10 year flood
- 36 inch 100 year flood

The below screenshot shows the 9 inch 10 year Flood Dataset:
![image](https://github.com/OpenGeoscience/uvdat/assets/44912689/43bd7e7d-06a7-45a7-af6f-fe8a59f1fdd2)
