### PR TITLE
Only use vector tiles on large datasets

### DIFF
--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -143,7 +143,7 @@ export function addDatasetLayerToMap(dataset, zIndex) {
   }
 
   // Use tiled GeoJSON if it exists
-  else if (dataset.tiled_geo_file) {
+  else if (dataset.vector_tiles_file) {
     layer = new VectorTileLayer({
       source: new VectorTileSource({
         format: new GeoJSON(),


### PR DESCRIPTION
@AlmightyYakob noticed that when we use tiled geojsons, vector data is blurry at high zoom levels. For small datasets, we can load in the whole geojson without too much wait time, so the tiling is not as necessary.

This PR reduces the role of tiled geojsons to large datasets only. The tiling step is now not being performed on small datasets, so they will have no file saved to the `tiled_geo_file` field. The client-side code to render a layer on the map will now determine whether to tile the layer by whether `tiled_geo_file` is defined for that dataset.