### PR TITLE
Add allauth account middleware to settings

### DIFF
--- a/uvdat/settings.py
+++ b/uvdat/settings.py
@@ -32,6 +32,8 @@ class UvdatMixin(ConfigMixin):
             's3_file_field',
         ]
 
+        configuration.MIDDLEWARE += ['allauth.account.middleware.AccountMiddleware']
+
         configuration.DATABASES = {
             'default': {
                 'ENGINE': 'django.contrib.gis.db.backends.postgis',


### PR DESCRIPTION
After rebuilding my docker image, I'm getting incessant errors about this allauth middleware setting, which prevent Django from running in any capacity.

@annehaley I'm curious to see if this works for you without issue on an existing (not recently rebuilt) local image.