### PR TITLE
Recovery simulations

### DIFF
--- a/uvdat/core/serializers.py
+++ b/uvdat/core/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from uvdat.core.models import Chart, City, Dataset, NetworkNode, SimulationResult
+from uvdat.core.tasks.simulations import AVAILABLE_SIMULATIONS
 
 
 class NetworkNodeSerializer(serializers.ModelSerializer):
@@ -45,6 +46,17 @@ class CitySerializer(serializers.ModelSerializer):
 
 
 class SimulationResultSerializer(serializers.ModelSerializer):
+    name = serializers.SerializerMethodField('get_name')
+
+    def get_name(self, obj):
+        time = obj.modified.strftime('%Y-%m-%d %H:%M')
+        simulation_type_matches = [t for t in AVAILABLE_SIMULATIONS if t['id'] == obj.simulation_id]
+        if len(simulation_type_matches) == 0:
+            return f'Result {time}'
+        else:
+            simulation_type = simulation_type_matches[0]
+            return f"{simulation_type['name']} Result {time}"
+
     class Meta:
         model = SimulationResult
         fields = '__all__'

--- a/uvdat/core/tasks/simulations.py
+++ b/uvdat/core/tasks/simulations.py
@@ -116,8 +116,7 @@ def recovery_scenario(simulation_result_id, node_failure_simulation_result, reco
             result.save()
             return
         edge_list = construct_edge_list(dataset)
-        int_edges = {int(k): v for k, v in edge_list.items()}
-        G = nx.from_dict_of_lists(int_edges)
+        G = nx.from_dict_of_lists(edge_list)
         nodes_sorted, edge_list = sort_graph_centrality(G, recovery_mode)
         node_recoveries.sort(key=lambda n: nodes_sorted.index(n))
 

--- a/uvdat/core/tasks/simulations.py
+++ b/uvdat/core/tasks/simulations.py
@@ -1,5 +1,7 @@
+import inspect
 import json
 from pathlib import Path
+import random
 import re
 import tempfile
 
@@ -8,8 +10,9 @@ from django_large_image import tilesource
 import large_image
 import shapely
 
+from rest_framework.serializers import ModelSerializer
 from uvdat.core.models import City, Dataset, SimulationResult
-from uvdat.core.serializers import DatasetSerializer, SimulationResultSerializer
+import uvdat.core.serializers as serializers
 
 
 def get_network_node_elevations(network_nodes, elevation_dataset):
@@ -49,7 +52,7 @@ def flood_scenario_1(simulation_result_id, network_dataset, elevation_dataset, f
     except Dataset.DoesNotExist:
         result.error_message = 'Dataset not found.'
         result.save()
-        return None
+        return
 
     if (
         not network_dataset.network
@@ -58,9 +61,9 @@ def flood_scenario_1(simulation_result_id, network_dataset, elevation_dataset, f
     ):
         result.error_message = 'Invalid dataset selected.'
         result.save()
-        return None
+        return
 
-    disabled_nodes = []
+    node_failures = []
     network_nodes = network_dataset.network_nodes.all()
     flood_geodata = json.loads(flood_dataset.geodata_file.open().read().decode())
     flood_areas = [
@@ -69,12 +72,47 @@ def flood_scenario_1(simulation_result_id, network_dataset, elevation_dataset, f
     for network_node in network_nodes:
         node_point = shapely.geometry.Point(*network_node.location)
         if any(flood_area.contains(node_point) for flood_area in flood_areas):
-            disabled_nodes.append(network_node)
+            node_failures.append(network_node)
 
     node_elevations = get_network_node_elevations(network_nodes, elevation_dataset)
-    disabled_nodes.sort(key=lambda n: node_elevations[n.id])
+    node_failures.sort(key=lambda n: node_elevations[n.id])
 
-    result.output_data = [n.id for n in disabled_nodes]
+    result.output_data = {'node_failures': [n.id for n in node_failures]}
+    result.save()
+
+
+@shared_task
+def recovery_scenario(simulation_result_id, node_failure_simulation_result, recovery_mode):
+    result = SimulationResult.objects.get(id=simulation_result_id)
+    try:
+        node_failure_simulation_result = SimulationResult.objects.get(
+            id=node_failure_simulation_result
+        )
+    except SimulationResult.DoesNotExist:
+        result.error_message = 'Node failure simulation result not found.'
+        result.save()
+        return
+    if recovery_mode not in [
+        'random',
+        'degree',
+        'betweenness',
+        'closeness',
+        'eigenvector',
+    ]:
+        result.error_message = f'Invalid recovery mode {recovery_mode}.'
+        result.save()
+        return
+
+    node_failures = node_failure_simulation_result.output_data['node_failures']
+    node_recoveries = []
+    if recovery_mode == 'random':
+        node_recoveries = node_failures.copy()
+        random.shuffle(node_recoveries)
+
+    result.output_data = {
+        'node_failures': node_failures,
+        'node_recoveries': node_recoveries,
+    }
     result.save()
 
 
@@ -87,7 +125,7 @@ AVAILABLE_SIMULATIONS = [
             to determine which network nodes go out of service
             when the target flood occurs.
         ''',
-        'output_type': 'node_failure_animation',
+        'output_type': 'node_animation',
         'func': flood_scenario_1,
         'args': [
             {
@@ -106,7 +144,36 @@ AVAILABLE_SIMULATIONS = [
                 'options_query': {'category': 'flood'},
             },
         ],
-    }
+    },
+    {
+        'id': 2,
+        'name': 'Recovery Scenario',
+        'description': '''
+            Provide the output of another simulation which returns a list of deactivated nodes,
+            and select a recovery mode to determine the order in which
+            nodes will come back online.
+        ''',
+        'output_type': 'node_animation',
+        'func': recovery_scenario,
+        'args': [
+            {
+                'name': 'node_failure_simulation_result',
+                'type': SimulationResult,
+                'options_query': {'simulation_id__in': [1]},
+            },
+            {
+                'name': 'recovery_mode',
+                'type': str,
+                'options': [
+                    'random',
+                    'degree',
+                    'betweenness',
+                    'closeness',
+                    'eigenvector',
+                ],
+            },
+        ],
+    },
 ]
 
 
@@ -115,21 +182,36 @@ def get_available_simulations(city_id: int):
     for available in AVAILABLE_SIMULATIONS:
         available = available.copy()
         available['description'] = re.sub(r'\n\s+', ' ', available['description'])
-        available['args'] = [
-            {
-                'name': a['name'],
-                'options': list(
-                    DatasetSerializer(d).data
-                    for d in a['type']
-                    .objects.filter(
-                        city__id=city_id,
-                        **a['options_query'],
+        args = []
+        for a in available['args']:
+            options = a.get('options')
+            if not options:
+                options_query = a.get('options_query')
+                options_type = a.get('type')
+                option_serializer_matches = [
+                    s
+                    for name, s in inspect.getmembers(serializers, inspect.isclass)
+                    if issubclass(s, ModelSerializer) and s.Meta.model == options_type
+                ]
+                if not options_query or not options_type or len(option_serializer_matches) == 0:
+                    options = []
+                else:
+                    option_serializer = option_serializer_matches[0]
+                    if hasattr(options_type, 'city'):
+                        options_query['city__id'] = city_id
+                    options = list(
+                        option_serializer(d).data
+                        for d in options_type.objects.filter(
+                            **options_query,
+                        ).all()
                     )
-                    .all()
-                ),
-            }
-            for a in available['args']
-        ]
+            args.append(
+                {
+                    'name': a['name'],
+                    'options': options,
+                }
+            )
+        available['args'] = args
         del available['func']
         sims.append(available)
     return sims
@@ -149,5 +231,5 @@ def run_simulation(simulation_id: int, city_id: int, **kwargs):
 
         simulation = simulation_matches[0]
         simulation['func'].delay(sim_result.id, **kwargs)
-        return SimulationResultSerializer(sim_result).data
+        return serializers.SimulationResultSerializer(sim_result).data
     return f"No simulation found with id {simulation_id}."

--- a/web/src/components/NodeAnimation.vue
+++ b/web/src/components/NodeAnimation.vue
@@ -11,7 +11,7 @@ export default {
       type: Array,
     },
     nodeRecoveries: {
-      required: true,
+      required: false,
       type: Array,
     },
   },
@@ -19,8 +19,6 @@ export default {
     const currentTick = ref(0);
     const ticker = ref();
     const seconds = ref(1);
-
-    console.log(props);
 
     const startState = computed(() => {
       if (props.nodeRecoveries?.length) return props.nodeFailures;

--- a/web/src/components/NodeAnimation.vue
+++ b/web/src/components/NodeAnimation.vue
@@ -1,5 +1,5 @@
 <script>
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import { deactivatedNodes } from "@/store";
 import { deactivatedNodesUpdated } from "@/utils";
 import { networkVis } from "../store";
@@ -10,11 +10,27 @@ export default {
       required: true,
       type: Array,
     },
+    nodeRecoveries: {
+      required: true,
+      type: Array,
+    },
   },
   setup(props) {
     const currentTick = ref(0);
     const ticker = ref();
     const seconds = ref(1);
+
+    console.log(props);
+
+    const startState = computed(() => {
+      if (props.nodeRecoveries?.length) return props.nodeFailures;
+      else return [];
+    });
+
+    const nodeChanges = computed(() => {
+      if (props.nodeRecoveries?.length) return props.nodeRecoveries;
+      else return props.nodeFailures;
+    });
 
     function pause() {
       clearInterval(ticker.value);
@@ -24,7 +40,7 @@ export default {
     function play() {
       pause();
       ticker.value = setInterval(() => {
-        if (currentTick.value < props.nodeFailures.length) {
+        if (currentTick.value < nodeChanges.value.length) {
           currentTick.value += 1;
         } else {
           pause();
@@ -44,11 +60,20 @@ export default {
     }
 
     watch(currentTick, () => {
-      deactivatedNodes.value = props.nodeFailures.slice(0, currentTick.value);
+      const slice = nodeChanges.value.slice(0, currentTick.value);
+      if (props.nodeRecoveries) {
+        // recovery mode
+        deactivatedNodes.value = startState.value.filter(
+          (i) => !slice.includes(i)
+        );
+      } else {
+        deactivatedNodes.value = slice;
+      }
       deactivatedNodesUpdated();
     });
 
     return {
+      nodeChanges,
       networkVis,
       currentTick,
       seconds,
@@ -74,7 +99,7 @@ export default {
       tick-size="5"
       min="0"
       step="1"
-      :max="nodeFailures.length"
+      :max="nodeChanges.length"
       hide-details
     />
   </div>


### PR DESCRIPTION
This PR adds a new Simulation type, "Recovery Scenario". For its input arguments, the user can select the following:

- an existing SimulationResult object from a node failure simulation
- a recovery mode from a list of strings: random, betweenness, degree, information, eigenvector, load, closeness, second order

![image](https://github.com/OpenGeoscience/uvdat/assets/44912689/e2e8ac4f-dc4c-4f98-b1db-35d08c7b4018)

The implementation of this simulation utilizes a function written by Jack Watson at NEU, shared with us for this simulation. The options available in that function determine the list of available recovery modes.

The animation of the results of this simulation only required a slight modification to the `NodeFailureAnimation` component, now renamed `NodeAnimation`. The component now accepts a list of `node_recoveries` alongside the list of `node_failures`. If `node_recoveries` is specified, the animation will subtract the current slice of recovered nodes from the list of failed nodes.

![image](https://github.com/OpenGeoscience/uvdat/assets/44912689/9d6e3aaa-2690-4aa8-9616-6bdd6eecab99)
