### PR TITLE
Pin django-allauth to <0.56.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'django==4.1',
         # TODO: remove django version constraint
         # when girder4 becomes compatible with 4.2
-        'django-allauth',
+        'django-allauth<0.56.0',
         'django-configurations[database,email]',
         'django-extensions',
         'django-filter',


### PR DESCRIPTION
Supercedes #22 

Fixes the following error showing up in Django locally
```
django.core.exceptions.ImproperlyConfigured: allauth.account.middleware.AccountMiddleware must be added to settings.MIDDLEWARE
```