### PR TITLE
Publishing server code as Docker image

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: uvdat/uvdat:server
+  IMAGE_NAME: opengeoscience/uvdat:server
 
 jobs:
   publish-uvdat-server:
@@ -29,4 +29,4 @@ jobs:
             context: .
             file: dev/Dockerfile
             push: ${{ github.actor != 'dependabot[bot]' }}
-            tags: ${{ env.IMAGE_NAME }}
+            tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,32 @@
+name: Publish Docker Packages
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: OpenGeoscience/uvdat:server
+
+jobs:
+  publish-uvdat-server:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: Log into the Container registry
+          uses: docker/login-action@v2
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: token
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build and push the Docker image
+          uses: docker/build-push-action@v3
+          with:
+            context: .
+            file: dev/Dockerfile
+            push: ${{ github.actor != 'dependabot[bot]' }}
+            tags: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: OpenGeoscience/uvdat:server
+  IMAGE_NAME: uvdat/uvdat:server
 
 jobs:
   publish-uvdat-server:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,28 @@
-name: Publish Docker Packages
+name: Release
 on:
   workflow_dispatch:
   push:
     branches:
       - master
-  pull_request:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: opengeoscience/uvdat:server
+  IMAGE_NAME: opengeoscience/uvdat-server
 
 jobs:
-  publish-uvdat-server:
+  tag-and-publish:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v3
           with:
             fetch-depth: 0
+
+        - name: Python Semantic Release
+          id: release
+          uses: python-semantic-release/python-semantic-release@master
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+
         - name: Log into the Container registry
           uses: docker/login-action@v2
           with:
@@ -29,4 +35,4 @@ jobs:
             context: .
             file: dev/Dockerfile
             push: ${{ github.actor != 'dependabot[bot]' }}
-            tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release.outputs.tag }}

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.10-slim
 # Install system libraries for Python packages:
-# * psycopg2
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
     libpq-dev libvips-dev gcc libc6-dev gdal-bin git && \
@@ -9,13 +8,11 @@ RUN apt-get update && \
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# Only copy the setup.py, it will still force all install_requires to be installed,
-# but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
-# over top of this directory, the .egg-link in site-packages resolves to the mounted directory
-# and all package modules are importable.
-COPY ./setup.py /opt/django-project/setup.py
+COPY ./setup.py /opt/uvdat-server/setup.py
+COPY ./manage.py /opt/uvdat-server/manage.py
+COPY ./uvdat /opt/uvdat-server/uvdat
 RUN pip install large-image[gdal,pil] large-image-converter --find-links https://girder.github.io/large_image_wheels
-RUN pip install --editable /opt/django-project[dev]
+RUN pip install --editable /opt/uvdat-server[dev]
 
 # Use a directory name which will never be an import name, as isort considers this as first-party.
-WORKDIR /opt/django-project
+WORKDIR /opt/uvdat-server

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,13 +3,13 @@ services:
   django:
     build:
       context: .
-      dockerfile: ./dev/django.Dockerfile
+      dockerfile: ./dev/Dockerfile
     command: [ "./manage.py", "runserver", "0.0.0.0:8000" ]
     # Log printing via Rich is enhanced by a TTY
     tty: true
     env_file: ./dev/.env.docker-compose
     volumes:
-      - .:/opt/django-project
+      - .:/opt/uvdat-server
     ports:
       - 8000:8000
     depends_on:
@@ -20,7 +20,7 @@ services:
   celery:
     build:
       context: .
-      dockerfile: ./dev/django.Dockerfile
+      dockerfile: ./dev/Dockerfile
     command:
       [
         "celery",
@@ -35,7 +35,7 @@ services:
     tty: false
     env_file: ./dev/.env.docker-compose
     volumes:
-      - .:/opt/django-project
+      - .:/opt/uvdat-server
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
This PR changes the Dockerfile used by the Django and Celery containers to make it more portable. The same Dockerfile is now used to publish an image on `ghcr.io`, which is publicly accessible here: https://github.com/orgs/OpenGeoscience/packages?repo_name=uvdat. We can use this server image on other projects where only the client application needs custom code.