### PR TITLE
Change docker compose GH Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - master
 
 jobs:
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -26,34 +25,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: adambirds/docker-compose-action@v1.3.0
+      - uses: hoverkraft-tech/compose-action@v2.0.1
         with:
           compose-file: |
             docker-compose.yml
             docker-compose.override.yml
-          services: |
-            django
-            celery
-            postgres
-            minio
-            rabbitmq
-          test-container: django
-          test-command: "tox -e test"
+      - run: |
+          docker compose exec django tox -e test
 
   check-migrations:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: adambirds/docker-compose-action@v1.3.0
+      - uses: hoverkraft-tech/compose-action@v2.0.1
         with:
           compose-file: |
             docker-compose.yml
             docker-compose.override.yml
-          services: |
-            django
-            celery
-            postgres
-            minio
-            rabbitmq
-          test-container: django
-          test-command: "tox -e check-migrations"
+      - run: |
+          docker compose exec django tox -e check-migrations


### PR DESCRIPTION
Previously, we used a GH action from `adambirds` to run our CI tests in the docker compose environment. It appears that it stopped working recently, because we consistently get errors like this for both our `pytest` and `check-migrations` jobs:
![image](https://github.com/user-attachments/assets/09d5fbda-500f-4367-b456-febaed1c3faf)

This PR switches to a similar GH action from `hoverkraft-tech`. There is a bit of syntax difference, but it achieves the same goal of running our tests in the docker compose environment.