### PR TITLE
Use improved NY Grid data

### DIFF
--- a/sample_data/use_cases/new_york_energy/datasets.json
+++ b/sample_data/use_cases/new_york_energy/datasets.json
@@ -36,7 +36,7 @@
         "category": "energy",
         "files": [
             {
-                "url": "https://data.kitware.com/api/v1/item/66a7bdab0ea2cce8e698b958/download",
+                "url": "https://data.kitware.com/api/v1/item/66cdd8a6886c56bdc7e282a4/download",
                 "path": "nyc/networks.zip"
             }
         ]

--- a/sample_data/use_cases/new_york_energy/import_networks.py
+++ b/sample_data/use_cases/new_york_energy/import_networks.py
@@ -79,7 +79,7 @@ def create_network(dataset, network_name, geodata):
 
 
 def perform_import(dataset, **kwargs):
-    print('\tEstimated time: 90 minutes.')
+    print('\tEstimated time: 45 minutes.')
     start = datetime.now()
     Network.objects.filter(dataset=dataset).delete()
     VectorMapLayer.objects.filter(dataset=dataset).delete()

--- a/sample_data/use_cases/new_york_energy/import_networks.py
+++ b/sample_data/use_cases/new_york_energy/import_networks.py
@@ -92,7 +92,7 @@ def perform_import(dataset, **kwargs):
                     filenames = zip_archive.namelist()
                     for filename in filenames:
                         if filename.endswith('.json'):
-                            network_name = filename.split('/')[-1].replace('.json', '')
+                            network_name = filename.split('/')[-1].replace('.json', '').title()
                             content = zip_archive.open(filename).read()
                             geodata = json.loads(content)
                             create_network(dataset, network_name, geodata)


### PR DESCRIPTION
This PR updates the reference to the NY Grid data on [DKC](https://data.kitware.com/#collection/649079b9f04fb368544295e1/folder/66a289dc5d2551c516b1e4f8). The populate script now pulls v2 of this data. The following improvements were made to the NY Grid networks:
- Remove non-intersection nodes and merge edges across removed nodes (this results in the removal of approximately 40% of features)
- Add county_name, is_substation, connected_substation_name, and tree_depth to node and edge metadata
- Remove metadata with empty keys

The following steps describe how to use the new data:
- Switch to this branch
- Delete the cached file at `sample_data/downloads/nyc/networks.zip`
- Run `python manage.py populate new_york_energy --dataset_indexes 3 --include_large` in the Django container and wait about 45 minutes (compared to 90 minutes with the previous version)

The following images demonstrate these improvements on the county of Schenectady:
![sch_removed_nodes](https://github.com/user-attachments/assets/a1bc67be-294e-4c9b-a81d-1714fa4dac3b)
![sch_substations](https://github.com/user-attachments/assets/fdfedbc6-872b-49b5-8297-3f2ca4ace788)
![sch_tree_depths](https://github.com/user-attachments/assets/f2080844-5eeb-4475-abb4-f071bf2e8b20)

There is still room for continued improvement; the images above illustrate that a significant portion of nodes are not connected to any substation due to data imperfections (e.g. lines not touching). The second image shows these nodes in pink, and the third image lacks these nodes because these nodes do not have a value for `tree_depth`. 