### PR TITLE
Prevent writing of file if request was not successful

### DIFF
--- a/sample_data/ingest_use_case.py
+++ b/sample_data/ingest_use_case.py
@@ -32,6 +32,7 @@ def ingest_file(file_info, index=0, dataset=None, chart=None):
         file_location.parent.mkdir(parents=True, exist_ok=True)
         with open(file_location, 'wb') as f:
             r = requests.get(file_url)
+            r.raise_for_status()
             f.write(r.content)
 
     existing = FileItem.objects.filter(name=file_name)


### PR DESCRIPTION
Closes #72

Currently, the request to retrieve certain files from DKC often fails with a `502 Bad Gateway`, but the file is still written to anyway. Since the file is only written to the first time, this means that if this bad request happens when first running `populate`, the bad file will remain there until the file item is deleted.