### PR TITLE
Use `pipx` for package installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: pip install tox
+      - name: Install Tox
+        uses: threeal/pipx-install-action@v1.0.0
+        with:
+          packages: tox
       - name: Lint
         run: tox -e lint
 


### PR DESCRIPTION
This PR modifies the lint job in our CI tests to prevent the occurence of `error: externally-managed-environment` during the `pip install tox` step. The error message recommends using pipx for environment management, so this PR uses a `pipx` Github action to complete the installation of tox prior to running the lint command.
See [this workflow run](https://github.com/OpenGeoscience/uvdat/actions/runs/11276851895/job/31361638107) for an example of the error.