### PR TITLE
Flood Timeseries Dataset

### DIFF
--- a/sample_data/use_cases/boston_floods/datasets.json
+++ b/sample_data/use_cases/boston_floods/datasets.json
@@ -241,6 +241,24 @@
         }
     },
     {
+        "name": "Boston Flood Timeseries",
+        "description": "46-hour flood simulation over the Boston Harbor Watershed",
+        "category": "flood",
+        "type": "raster",
+        "files": [
+            {
+                "url": "https://data.kitware.com/api/v1/item/6564cc5ac5a2b36857ad16cf/download",
+                "path": "boston/flood_timeseries.zip",
+                "metadata": {
+                    "source": "Simulated by Jack Watson at Northeastern University"
+                }
+            }
+        ],
+        "style_options": {
+            "transparency_threshold": -1
+        }
+    },
+    {
         "name": "DC Metro",
         "description": "DC Metro Lines and Stations",
         "category": "transportation",

--- a/sample_data/use_cases/boston_floods/projects.json
+++ b/sample_data/use_cases/boston_floods/projects.json
@@ -17,7 +17,8 @@
             "Boston Zip Codes",
             "Boston Sea Level Rises",
             "Boston 10-Year Flood Events",
-            "Boston 100-Year Flood Events"
+            "Boston 100-Year Flood Events",
+            "Boston Flood Timeseries"
         ]
     },
     {

--- a/uvdat/core/tasks/dataset.py
+++ b/uvdat/core/tasks/dataset.py
@@ -19,6 +19,12 @@ def convert_dataset(
     dataset.processing = True
     dataset.save()
 
+    # remove any existing generated files
+    generated_files = FileItem.objects.filter(
+        dataset=dataset,
+        metadata__generated=True
+    ).delete()
+
     if dataset.dataset_type == dataset.DatasetType.RASTER:
         RasterMapLayer.objects.filter(dataset=dataset).delete()
         for file_to_convert in FileItem.objects.filter(dataset=dataset):

--- a/uvdat/core/tasks/dataset.py
+++ b/uvdat/core/tasks/dataset.py
@@ -20,10 +20,7 @@ def convert_dataset(
     dataset.save()
 
     # remove any existing generated files
-    generated_files = FileItem.objects.filter(
-        dataset=dataset,
-        metadata__generated=True
-    ).delete()
+    generated_files = FileItem.objects.filter(dataset=dataset, metadata__generated=True).delete()
 
     if dataset.dataset_type == dataset.DatasetType.RASTER:
         RasterMapLayer.objects.filter(dataset=dataset).delete()

--- a/uvdat/core/tasks/dataset.py
+++ b/uvdat/core/tasks/dataset.py
@@ -20,7 +20,7 @@ def convert_dataset(
     dataset.save()
 
     # remove any existing generated files
-    generated_files = FileItem.objects.filter(dataset=dataset, metadata__generated=True).delete()
+    FileItem.objects.filter(dataset=dataset, metadata__generated=True).delete()
 
     if dataset.dataset_type == dataset.DatasetType.RASTER:
         RasterMapLayer.objects.filter(dataset=dataset).delete()

--- a/uvdat/core/tasks/map_layers.py
+++ b/uvdat/core/tasks/map_layers.py
@@ -49,7 +49,8 @@ def add_styling(geojson_data, style_options):
 
 def split_raster_zip(file_item, style_options):
     """For each raster image in a zip file, create a new FileItem."""
-    # NOTE: This implementation is not abstract; this was built for the Boston Flood Timeseries dataset.
+    # NOTE: This implementation is not abstract;
+    # this was built for the Boston Flood Timeseries dataset.
     import large_image_converter
 
     if file_item.file_type == 'zip':

--- a/uvdat/core/tasks/map_layers.py
+++ b/uvdat/core/tasks/map_layers.py
@@ -66,7 +66,7 @@ def split_raster_zip(file_item, style_options):
                 archive_file.write(file_item.file.open('rb').read())
                 # unzip all
                 with zipfile.ZipFile(archive_path) as zip_archive:
-                   zip_archive.extractall(extracted_path)
+                    zip_archive.extractall(extracted_path)
             # read VRT files
             vrt_files = list(extracted_path.glob('**/*.vrt'))
             vrt_files.sort()  # rely on filenames for ordering
@@ -88,9 +88,7 @@ def split_raster_zip(file_item, style_options):
                     metadata=metadata,
                 )
                 with open(cog_filepath, 'rb') as cog:
-                    new_file_item.file.save(
-                        cog_filepath, ContentFile(cog.read())
-                    )
+                    new_file_item.file.save(cog_filepath, ContentFile(cog.read()))
                 if cog_size > 0:
                     create_raster_map_layer(new_file_item, style_options)
 

--- a/web/src/components/OptionsDrawerContents.vue
+++ b/web/src/components/OptionsDrawerContents.vue
@@ -54,6 +54,7 @@ export default {
     const layerRange = ref<number[]>([]);
     const colormapRange = ref<number[]>([]);
     const applyToAll = ref<boolean>(true);
+    const ticker = ref();
 
     const allowOpacityModification = computed(
       () =>
@@ -220,6 +221,37 @@ export default {
       opacity.value = 1;
     }
 
+    function pause() {
+      clearInterval(ticker.value);
+      ticker.value = undefined;
+    }
+    function play() {
+      if (currentDataset.value?.map_layers) {
+        pause();
+        ticker.value = setInterval(() => {
+          if (
+            currentDataset.value?.map_layers &&
+            currentDatasetLayerIndex.value <
+              currentDataset.value.map_layers?.length - 1
+          ) {
+            currentDatasetLayerIndex.value += 1;
+          } else {
+            pause();
+          }
+        }, 2000);
+      }
+    }
+    function rewind() {
+      pause();
+      ticker.value = setInterval(() => {
+        if (currentDatasetLayerIndex.value > 0) {
+          currentDatasetLayerIndex.value -= 1;
+        } else {
+          pause();
+        }
+      }, 2000);
+    }
+
     watch(colormap, updateColormap);
     watch(opacity, updateLayerOpacity);
 
@@ -245,6 +277,9 @@ export default {
       getNetworkNodeName,
       updateColormap,
       resetNetwork,
+      play,
+      pause,
+      rewind,
     };
   },
 };
@@ -283,8 +318,14 @@ export default {
         dense
         min="0"
         step="1"
+        hide-details
         :max="currentDataset?.map_layers.length - 1"
       />
+      <div style="width: 100%; text-align: center">
+        <v-btn @click="play" icon="mdi-play" variant="text" />
+        <v-btn @click="pause" icon="mdi-pause" variant="text" />
+        <v-btn @click="rewind" icon="mdi-rewind" variant="text" />
+      </div>
       <v-card-subtitle class="wrap-subtitle">
         Current layer name: {{ currentLayerName || "Untitled" }}
       </v-card-subtitle>


### PR DESCRIPTION
Resolves #75.

This PR adds the simulated flood timeseries dataset created by Jack Watson. This involves the addition of a custom ingest function to split a single zip file item into many tiff file items. The current implementation is not abstracted; it relies on the presence of `vrt` files in the zip and relies on the file names to assert ordering.

Additionally, this PR adds animation controls to the current layer slider so that the user can automatically step through the layers on a dataset. The video (2x speed) below demonstrates this behavior on the flood timeseries dataset.

https://github.com/user-attachments/assets/68d8352d-f502-4407-8c22-263eae605f21