### PR TITLE
Add precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          [
+            flake8-black,
+            flake8-bugbear,
+            flake8-docstrings,
+            flake8-isort,
+            flake8-quotes,
+            pep8-naming,
+          ]
+        args: ["--ignore=E123,E203,W503,D10"]
+        exclude: "sample_data"
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             'django-s3-file-field[minio]==1.0.1',
             'ipython==8.26.0',
             'tox==4.16.0',
+            'precommit==4.0.1',
         ],
         'test': [
             'factory-boy==3.3.1',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             'django-s3-file-field[minio]==1.0.1',
             'ipython==8.26.0',
             'tox==4.16.0',
-            'precommit==4.0.1',
+            'pre-commit==4.0.1',
         ],
         'test': [
             'factory-boy==3.3.1',


### PR DESCRIPTION
Resolves #88.

This PR adds `.pre-commit-config.yaml` to the top-level of this repository so that we can run pre-commit checks during development. These checks include linting with `flake8` and confirming that the commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) structure (so that our semantic release CI job can interpret them).

To install:
```
pip install pre-commit
pre-commit install --hook-type commit-msg
``` 