### PR TITLE
Fix edge cases with create_{vector,raster}_map_layer

### DIFF
--- a/uvdat/core/tasks/map_layers.py
+++ b/uvdat/core/tasks/map_layers.py
@@ -102,6 +102,8 @@ def create_raster_map_layer(file_item, style_options):
     import large_image
     import large_image_converter
 
+    style_options = style_options or {}
+
     # create new raster map layer object
     new_map_layer = RasterMapLayer.objects.create(
         dataset=file_item.dataset,
@@ -171,6 +173,8 @@ def create_raster_map_layer(file_item, style_options):
 
 def create_vector_map_layer(file_item, style_options):
     """Save a VectorMapLayer from a FileItem's contents."""
+    style_options = style_options or {}
+
     new_map_layer = VectorMapLayer.objects.create(
         dataset=file_item.dataset,
         metadata={},

--- a/uvdat/core/tasks/map_layers.py
+++ b/uvdat/core/tasks/map_layers.py
@@ -192,6 +192,8 @@ def create_vector_map_layer(file_item, style_options):
         if source_projection:
             geojson_data = geojson_data.set_crs(source_projection)
             geojson_data = geojson_data.to_crs(4326)
+    else:
+        raise ValueError(f'Cannot handle file type "{file_item.file_type}"')
 
     geojson_data = add_styling(geojson_data, style_options)
     new_map_layer.write_geojson_data(geojson_data.to_json())


### PR DESCRIPTION
- `style_options` can be None, since we don't have schema validation for input `datasets.json`
- Passing in a vector filename with an unsupported extension results in `geojson_data` not being defined.