### PR TITLE
Add LA wildfires as a use-case

### DIFF
--- a/sample_data/ingest_use_case.py
+++ b/sample_data/ingest_use_case.py
@@ -13,6 +13,7 @@ from uvdat.core.models import Chart, Project, Dataset, FileItem
 
 from .use_cases.boston_floods import ingest as boston_floods_ingest
 from .use_cases.new_york_energy import ingest as new_york_energy_ingest
+from .use_cases.la_wildfires import ingest as la_wildfires_ingest
 
 
 USE_CASE_FOLDER = Path('sample_data/use_cases')
@@ -151,6 +152,8 @@ def ingest_datasets(use_case, include_large=False, dataset_indexes=None):
                             boston_floods_ingest.convert_dataset(dataset_for_conversion, dataset)
                         elif use_case == 'new_york_energy':
                             new_york_energy_ingest.convert_dataset(dataset_for_conversion, dataset)
+                        elif use_case == 'la_wildfires':
+                            la_wildfires_ingest.convert_dataset(dataset_for_conversion, dataset)
                     else:
                         print(
                             '\t', f'Dataset too large ({dataset_size_mb} MB); skipping conversion step.'

--- a/sample_data/use_cases/la_wildfires/datasets.json
+++ b/sample_data/use_cases/la_wildfires/datasets.json
@@ -1,0 +1,79 @@
+[
+    {
+        "name": "MODIS 1km 48h USA + Hawaii",
+        "description": "MODIS 1km USA (Conterminous) + Hawaii 48h shapefile. From: https://firms.modaps.eosdis.nasa.gov/active_fire/",
+        "category": "region",
+        "type": "vector",
+        "files": [
+            {
+                "path": "la-fire-2025/modis-1-48.zip",
+                "url": "https://data.kitware.com/api/v1/item/67aa368b091a514e82eec908/download"
+            }
+        ],
+        "style_options": {}
+    },
+    {
+        "name": "USA Palisades + Eaton Wildfire Perimeters",
+        "description": "NIFC, taken on Feb 4, 2025. From: https://data-nifc.opendata.arcgis.com/",
+        "category": "region",
+        "type": "vector",
+        "files": [
+            {
+                "path": "la-fire-2025/current_fire_perimeters.geojson",
+                "url": "https://data.kitware.com/api/v1/item/67aa368c091a514e82eec90b/download"
+            }
+        ]
+    },
+    {
+        "name": "USA Palisades + Eaton Wildfire Incidents",
+        "description": "IRWIN, taken on Feb 4, 2025. From: https://forestsandrangelands.gov/WFIT/applications/IRWIN/index.shtml",
+        "category": "region",
+        "type": "vector",
+        "files": [
+            {
+                "path": "la-fire-2025/current_fire_incidents.geojson",
+                "url": "https://data.kitware.com/api/v1/item/67aa368c091a514e82eec90e/download"
+            }
+        ],
+        "style_options": {}
+    },
+    {
+        "name": "California Fire Perimeters",
+        "description": "NIFC + FIRIS, taken Feb 4, 2025. From: https://www.fire.ca.gov/incidents/2025/1/7/palisades-fire",
+        "category": "region",
+        "type": "vector",
+        "files": [
+            {
+                "path": "la-fire-2025/ca_perimeters_nifc_firis.geojson",
+                "url": "https://data.kitware.com/api/v1/item/67aa33ed091a514e82eec8ff/download"
+            }
+        ],
+        "style_options": {}
+    },
+    {
+        "name": "Palisades Satellite Imagery",
+        "description": "MAXAR, Jan 14, 2025. From: https://registry.opendata.aws/maxar-open-data/",
+        "category": "region",
+        "type": "raster",
+        "files": [
+            {
+                "path": "la-fire-2025/palidades-2025-01-14.tif",
+                "url": "https://data.kitware.com/api/v1/item/67aa368a091a514e82eec905/download"
+            }
+        ],
+        "style_options": {}
+    },
+    {
+        "name": "Eaton/Altadena Satellite Imagery",
+        "description": "MAXAR, Jan 14-19, 2025. From: https://registry.opendata.aws/maxar-open-data/",
+        "category": "region",
+        "type": "raster",
+        "files": [
+            {
+                "path": "la-fire-2025/eaton-2025-01-14_to_19.tif",
+                "url": "https://data.kitware.com/api/v1/item/67aa353a091a514e82eec902/download"
+            }
+        ],
+        "style_options": {}
+    }
+]

--- a/sample_data/use_cases/la_wildfires/datasets.json
+++ b/sample_data/use_cases/la_wildfires/datasets.json
@@ -13,7 +13,7 @@
         "style_options": {}
     },
     {
-        "name": "USA Palisades + Eaton Wildfire Perimeters",
+        "name": "USA Current Wildfire Perimeters",
         "description": "NIFC, taken on Feb 4, 2025. From: https://data-nifc.opendata.arcgis.com/",
         "category": "region",
         "type": "vector",
@@ -25,7 +25,7 @@
         ]
     },
     {
-        "name": "USA Palisades + Eaton Wildfire Incidents",
+        "name": "USA Current Wildfire Incidents",
         "description": "IRWIN, taken on Feb 4, 2025. From: https://forestsandrangelands.gov/WFIT/applications/IRWIN/index.shtml",
         "category": "region",
         "type": "vector",

--- a/sample_data/use_cases/la_wildfires/ingest.py
+++ b/sample_data/use_cases/la_wildfires/ingest.py
@@ -1,0 +1,8 @@
+def convert_dataset(dataset, options):
+    print('\t', f'Converting data for {dataset.name}...')
+    dataset.spawn_conversion_task(
+        style_options=options.get('style_options'),
+        network_options=options.get('network_options'),
+        region_options=options.get('region_options'),
+        asynchronous=False,
+    )

--- a/sample_data/use_cases/la_wildfires/projects.json
+++ b/sample_data/use_cases/la_wildfires/projects.json
@@ -5,7 +5,14 @@
             34.27,
             -118.47
         ],
-        "default_map_zoom": 10,
-        "datasets": []
+        "default_map_zoom": 9,
+        "datasets": [
+            "MODIS 1km 48h USA + Hawaii",
+            "USA Current Wildfire Perimeters",
+            "USA Current Wildfire Incidents",
+            "California Fire Perimeters",
+            "Palisades Satellite Imagery",
+            "Eaton/Altadena Satellite Imagery"
+        ]
     }
 ]

--- a/sample_data/use_cases/la_wildfires/projects.json
+++ b/sample_data/use_cases/la_wildfires/projects.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "Los Angeles Wildfires (Jan 2025)",
+        "default_map_center": [
+            34.27,
+            -118.47
+        ],
+        "default_map_zoom": 10,
+        "datasets": []
+    }
+]

--- a/uvdat/core/management/commands/populate.py
+++ b/uvdat/core/management/commands/populate.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             'use_case',
-            choices=['boston_floods', 'new_york_energy'],
+            choices=['boston_floods', 'new_york_energy', 'la_wildfires'],
             help='Sample data collection to load',
         )
         parser.add_argument(


### PR DESCRIPTION
Datasets:
- MODIS 1km 48h USA + Hawaii: MODIS 1km USA (Conterminous) + Hawaii 48h shapefile. From: https://firms.modaps.eosdis.nasa.gov/active_fire/
- USA Palisades + Eaton Wildfire Perimeters: NIFC, taken on Feb 4, 2025. From: https://data-nifc.opendata.arcgis.com/
- USA Palisades + Eaton Wildfire Incidents: IRWIN, taken on Feb 4, 2025. From: https://forestsandrangelands.gov/WFIT/applications/IRWIN/index.shtml
- California Fire Perimeters: NIFC + FIRIS, taken Feb 4, 2025. From: https://www.fire.ca.gov/incidents/2025/1/7/palisades-fire
- Palisades Satellite Imager: MAXAR, Jan 14, 2025. From: https://registry.opendata.aws/maxar-open-data/
- Eaton/Altadena Satellite Imagery: MAXAR, Jan 14-19, 2025. From: https://registry.opendata.aws/maxar-open-data/

The satellite images cover smaller areas than their related fires to minimize download time.

FYI @aashish24 

Sample view:
![image](https://github.com/user-attachments/assets/a91a4756-2acd-4f15-ab2d-e647eeb01200)
