### PR TITLE
Additional API updates

### DIFF
--- a/uvdat/core/admin.py
+++ b/uvdat/core/admin.py
@@ -88,10 +88,7 @@ class RegionAdmin(admin.ModelAdmin):
 
 
 class NetworkAdmin(admin.ModelAdmin):
-    list_display = ['id', 'category', 'get_dataset_name']
-
-    def get_dataset_name(self, obj):
-        return obj.dataset.name
+    list_display = ['id', 'category']
 
 
 class NetworkEdgeAdmin(admin.ModelAdmin):

--- a/uvdat/core/rest/__init__.py
+++ b/uvdat/core/rest/__init__.py
@@ -2,6 +2,7 @@ from .chart import ChartViewSet
 from .data import RasterDataViewSet, VectorDataViewSet
 from .dataset import DatasetViewSet
 from .layer import LayerFrameViewSet, LayerViewSet
+from .networks import NetworkViewSet
 from .project import ProjectViewSet
 from .regions import RegionViewSet
 from .simulations import SimulationViewSet
@@ -15,6 +16,7 @@ __all__ = [
     RasterDataViewSet,
     VectorDataViewSet,
     DatasetViewSet,
+    NetworkViewSet,
     RegionViewSet,
     SimulationViewSet,
     UserViewSet,

--- a/uvdat/core/rest/dataset.py
+++ b/uvdat/core/rest/dataset.py
@@ -1,25 +1,16 @@
-from drf_yasg.utils import swagger_auto_schema
-from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from uvdat.core.models import Dataset, Network, NetworkEdge, NetworkNode
+from uvdat.core.models import Dataset
 from uvdat.core.rest.access_control import GuardianFilter, GuardianPermission
 from uvdat.core.rest.serializers import (
     DatasetSerializer,
     LayerSerializer,
-    NetworkEdgeSerializer,
-    NetworkNodeSerializer,
+    NetworkSerializer,
     RasterDataSerializer,
     VectorDataSerializer,
 )
-from uvdat.core.tasks.chart import add_gcc_chart_datum
-
-
-class GCCQueryParamSerializer(serializers.Serializer):
-    project = serializers.IntegerField()
-    exclude_nodes = serializers.RegexField(r'^\d+(,\s?\d+)*$')
 
 
 class DatasetViewSet(ReadOnlyModelViewSet):
@@ -56,47 +47,9 @@ class DatasetViewSet(ReadOnlyModelViewSet):
         return Response(data, status=200)
 
     @action(detail=True, methods=['get'])
-    def network(self, request, **kwargs):
+    def networks(self, request, **kwargs):
         dataset = self.get_object()
-        networks = []
-        for network in dataset.get_networks().all():
-            networks.append(
-                {
-                    'nodes': [
-                        NetworkNodeSerializer(n).data
-                        for n in NetworkNode.objects.filter(network=network)
-                    ],
-                    'edges': [
-                        NetworkEdgeSerializer(e).data
-                        for e in NetworkEdge.objects.filter(network=network)
-                    ],
-                }
-            )
-        return Response(networks, status=200)
-
-    @swagger_auto_schema(query_serializer=GCCQueryParamSerializer)
-    @action(detail=True, methods=['get'])
-    def gcc(self, request, **kwargs):
-        dataset = self.get_object()
-
-        # Validate and de-serialize query params
-        serializer = GCCQueryParamSerializer(data=request.query_params)
-        serializer.is_valid(raise_exception=True)
-        project_id = serializer.validated_data['project']
-        exclude_nodes = [int(n) for n in serializer.validated_data['exclude_nodes'].split(',')]
-
-        if not dataset.get_networks().exists():
-            return Response(data='No networks exist in selected dataset', status=400)
-
-        # Find the GCC for each network in the dataset
-        network_gccs: list[list[int]] = []
-        for network in dataset.get_networks().all():
-            network: Network
-            network_gccs.append(network.get_gcc(excluded_nodes=exclude_nodes))
-
-        # TODO: improve this for datasets with multiple networks.
-        # This currently returns the gcc for the network with the most excluded nodes
-        gcc = max(network_gccs, key=len)
-
-        add_gcc_chart_datum(dataset, project_id, exclude_nodes, len(gcc))
-        return Response(gcc, status=200)
+        return Response(
+            [NetworkSerializer(network).data for network in dataset.get_networks().all()],
+            status=200,
+        )

--- a/uvdat/core/rest/networks.py
+++ b/uvdat/core/rest/networks.py
@@ -1,0 +1,34 @@
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import serializers
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from uvdat.core.models import Network
+from uvdat.core.rest.access_control import GuardianFilter, GuardianPermission
+from uvdat.core.rest.serializers import NetworkSerializer
+
+
+class GCCQueryParamSerializer(serializers.Serializer):
+    exclude_nodes = serializers.RegexField(r'^\d+(,\s?\d+)*$')
+
+
+class NetworkViewSet(ModelViewSet):
+    queryset = Network.objects.all()
+    serializer_class = NetworkSerializer
+    permission_classes = [GuardianPermission]
+    filter_backends = [GuardianFilter]
+    lookup_field = 'id'
+
+    @swagger_auto_schema(query_serializer=GCCQueryParamSerializer)
+    @action(detail=True, methods=['get'])
+    def gcc(self, request, **kwargs):
+        network = self.get_object()
+
+        # Validate and de-serialize query params
+        serializer = GCCQueryParamSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        exclude_nodes = [int(n) for n in serializer.validated_data['exclude_nodes'].split(',')]
+
+        gcc = network.get_gcc(excluded_nodes=exclude_nodes)
+        return Response(gcc, status=200)

--- a/uvdat/core/rest/networks.py
+++ b/uvdat/core/rest/networks.py
@@ -13,6 +13,10 @@ class GCCQueryParamSerializer(serializers.Serializer):
     exclude_nodes = serializers.RegexField(r'^\d+(,\s?\d+)*$')
 
 
+class GCCResultSerializer(serializers.Serializer):
+    gcc = serializers.ListField(child=serializers.IntegerField())
+
+
 class NetworkViewSet(ModelViewSet):
     queryset = Network.objects.all()
     serializer_class = NetworkSerializer
@@ -31,4 +35,6 @@ class NetworkViewSet(ModelViewSet):
         exclude_nodes = [int(n) for n in serializer.validated_data['exclude_nodes'].split(',')]
 
         gcc = network.get_gcc(excluded_nodes=exclude_nodes)
-        return Response(gcc, status=200)
+        result = GCCResultSerializer(data=dict(gcc=gcc))
+        if result.is_valid():
+            return Response(result.data.get('gcc'), status=200)

--- a/uvdat/core/rest/networks.py
+++ b/uvdat/core/rest/networks.py
@@ -36,5 +36,5 @@ class NetworkViewSet(ModelViewSet):
 
         gcc = network.get_gcc(excluded_nodes=exclude_nodes)
         result = GCCResultSerializer(data=dict(gcc=gcc))
-        if result.is_valid():
-            return Response(result.data.get('gcc'), status=200)
+        result.is_valid(raise_exception=True)
+        return Response(result.validated_data['gcc'], status=200)

--- a/uvdat/core/rest/serializers.py
+++ b/uvdat/core/rest/serializers.py
@@ -142,12 +142,6 @@ class RegionFeatureCollectionSerializer(geojson.Serializer):
         return val
 
 
-class NetworkSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Network
-        fields = '__all__'
-
-
 class NetworkNodeSerializer(serializers.ModelSerializer):
     class Meta:
         model = NetworkNode
@@ -157,6 +151,15 @@ class NetworkNodeSerializer(serializers.ModelSerializer):
 class NetworkEdgeSerializer(serializers.ModelSerializer):
     class Meta:
         model = NetworkEdge
+        fields = '__all__'
+
+
+class NetworkSerializer(serializers.ModelSerializer):
+    nodes = NetworkNodeSerializer(many=True, read_only=True)
+    edges = NetworkEdgeSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Network
         fields = '__all__'
 
 

--- a/uvdat/core/rest/tokenauth.py
+++ b/uvdat/core/rest/tokenauth.py
@@ -7,6 +7,9 @@ from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 
 class TokenAuth(OAuth2Authentication):
     def authenticate(self, request):
+        auth = super().authenticate(request)
+        if auth is not None:
+            return auth
         token = request.query_params.get('token')
         if token is None:
             token_string = request.headers.get('Authorization')

--- a/uvdat/core/tasks/networks.py
+++ b/uvdat/core/tasks/networks.py
@@ -23,9 +23,10 @@ NODE_RECOVERY_MODES = [
 def create_network(vector_data, network_options):
     # Overwrite previous results
     dataset = vector_data.dataset
-    Network.objects.filter(vector_data__dataset=dataset).delete()
+    Network.objects.filter(vector_data=vector_data).delete()
+    existing = Network.objects.filter(vector_data__dataset=dataset)
     network = Network.objects.create(
-        name=dataset.name + ' Network',
+        name=f'{dataset.name} Network {existing.count() + 1}',
         category=dataset.category,
         vector_data=vector_data,
         metadata={'source': 'Parsed from GeoJSON.'},

--- a/uvdat/core/tasks/networks.py
+++ b/uvdat/core/tasks/networks.py
@@ -25,6 +25,7 @@ def create_network(vector_data, network_options):
     dataset = vector_data.dataset
     Network.objects.filter(vector_data__dataset=dataset).delete()
     network = Network.objects.create(
+        name=dataset.name + ' Network',
         category=dataset.category,
         vector_data=vector_data,
         metadata={'source': 'Parsed from GeoJSON.'},

--- a/uvdat/core/tests/test_network.py
+++ b/uvdat/core/tests/test_network.py
@@ -1,0 +1,90 @@
+import itertools
+
+import pytest
+
+from uvdat.core.models import Dataset, Network, NetworkNode, Project
+
+
+@pytest.mark.django_db
+def test_rest_dataset_networks_no_network(
+    authenticated_api_client, dataset: Dataset, project: Project
+):
+    project.datasets.add(dataset)
+    resp = authenticated_api_client.get(f'/api/v1/datasets/{dataset.id}/networks/')
+    assert resp.status_code == 200
+    assert not resp.json()
+
+
+@pytest.mark.django_db
+def test_rest_dataset_networks(authenticated_api_client, project: Project, network_edge):
+    network = network_edge.network
+    dataset = network.vector_data.dataset
+    project.datasets.add(dataset)
+    assert network_edge.from_node != network_edge.to_node
+
+    resp = authenticated_api_client.get(f'/api/v1/datasets/{dataset.id}/networks/')
+    assert resp.status_code == 200
+
+    data: list[dict] = resp.json()
+    assert len(data) == 1
+
+    data: dict = data[0]
+    assert len(data['nodes']) == 2
+    assert len(data['edges']) == 1
+
+
+@pytest.mark.django_db
+def test_rest_network_gcc_empty(authenticated_api_client, user, project: Project, network: Network):
+    dataset = network.vector_data.dataset
+    project.set_owner(user)
+    project.datasets.add(dataset)
+    resp = authenticated_api_client.get(f'/api/v1/networks/{network.id}/gcc/?exclude_nodes=1')
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.parametrize('group_sizes', [(3, 2), (20, 3)])
+@pytest.mark.django_db
+def test_rest_network_gcc(
+    authenticated_api_client,
+    user,
+    project: Project,
+    network: Network,
+    network_edge_factory,
+    network_node_factory,
+    group_sizes,
+):
+    dataset = network.vector_data.dataset
+    project.set_owner(user)
+    project.datasets.add(dataset)
+    group_a_size, group_b_size = group_sizes
+
+    # Create two groups of nodes that fully connected
+    group_a = [network_node_factory(network=network) for _ in range(group_a_size)]
+    for from_node, to_node in itertools.combinations(group_a, 2):
+        network_edge_factory(network=network, from_node=from_node, to_node=to_node)
+
+    group_b = [network_node_factory(network=network) for _ in range(group_b_size)]
+    for from_node, to_node in itertools.combinations(group_b, 2):
+        network_edge_factory(network=network, from_node=from_node, to_node=to_node)
+
+    # Join these two groups by a single node
+    connecting_node: NetworkNode = network_node_factory(network=network)
+    network_edge_factory(network=network, from_node=group_a[0], to_node=connecting_node)
+    network_edge_factory(network=network, from_node=group_b[0], to_node=connecting_node)
+
+    # Network should look like this
+    #  *             *
+    #  |             |
+    #  * ---- * ---- *
+    #  |
+    #  *
+
+    resp = authenticated_api_client.get(
+        f'/api/v1/networks/{network.id}/gcc/?exclude_nodes={connecting_node.id}'
+    )
+
+    larger_group: list[NetworkNode] = max(group_a, group_b, key=len)
+    assert resp.status_code == 200
+    assert sorted(resp.json()) == sorted([n.id for n in larger_group])

--- a/uvdat/urls.py
+++ b/uvdat/urls.py
@@ -12,6 +12,7 @@ from uvdat.core.rest import (
     DatasetViewSet,
     LayerFrameViewSet,
     LayerViewSet,
+    NetworkViewSet,
     ProjectViewSet,
     RasterDataViewSet,
     RegionViewSet,
@@ -38,6 +39,8 @@ router.register(r'rasters', RasterDataViewSet, basename='rasters')
 router.register(r'vectors', VectorDataViewSet, basename='vectors')
 router.register(r'source-regions', RegionViewSet, basename='source-regions')
 router.register(r'simulations', SimulationViewSet, basename='simulations')
+router.register(r'networks', NetworkViewSet, basename='networks')
+
 
 urlpatterns = [
     path('accounts/', include('allauth.urls')),


### PR DESCRIPTION
In the course of continuing UI updates on #102, I found some more server-side changes that are needed to use the new Network model in our API. This includes an update to the new `TokenAuth` class and a new set of viewpoints for Networks. The client will now leverage these endpoints for Network-related logic (rather than going through Dataset endpoints, since the relationship between a Network and a Dataset is no longer one-to-one).