### PR TITLE
Constrain map tooltip height with scroll

### DIFF
--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -146,7 +146,7 @@ function toggleNodeHandler() {
 </script>
 
 <template>
-  <div v-if="clickedFeature && clickedFeatureSourceType === 'vector'">
+  <div v-if="clickedFeature && clickedFeatureSourceType === 'vector'" style="max-height: 50vh; overflow: auto">
     <RecursiveTable :data="clickedFeatureProperties" />
 
     <!-- Render for Source Regions -->


### PR DESCRIPTION
Constrains the map tooltips to be 50% of the viewport height with overflow scrolling.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/355c9b00-7a83-4402-a3e8-22e507647ba6" />
