### PR TITLE
Show tooltips below layer name

### DIFF
--- a/web/src/components/sidebars/DatasetsPanel.vue
+++ b/web/src/components/sidebars/DatasetsPanel.vue
@@ -63,15 +63,20 @@ function toggleSelected(items: Layer[]) {
               class="item-title"
             >
               <div
-                style="text-wrap: wrap; align-items: center; width: 90%"
+                style="text-wrap: wrap; align-items: center; width: 90%; cursor: pointer"
                 @click.stop="() => toggleSelected([layer])"
               >
-                <v-icon
-                  icon="mdi-plus"
-                  color="primary"
-                  v-tooltip="'Add to Selected Layers'"
-                  class="layer-select-button"
-                ></v-icon>
+                <span>
+                  <v-icon
+                    icon="mdi-plus"
+                    color="primary"
+                    class="layer-select-button"
+                  >
+                  </v-icon>
+                  <v-tooltip activator="parent" location="bottom">
+                    Add to Selected Layers
+                  </v-tooltip>
+                </span>
                 {{ layer.name }}
               </div>
             </div>

--- a/web/src/themes.ts
+++ b/web/src/themes.ts
@@ -7,7 +7,7 @@ export const THEMES = {
             surface: "#EDEEF0", // sidebars, menus
             "surface-bright": "#FFFFFF", // floating panels
             "surface-light": "#F5F5F5", // toolbars
-            "surface-variant": "#FFFFFF", // tooltip background
+            "surface-variant": "#DDDDDD", // tooltip background
             "on-surface-variant": "#141516", // tooltip text
             "secondary-darken-1": "#018786", // overlay scrim
             "primary-text": "#141516",
@@ -30,7 +30,7 @@ export const THEMES = {
             surface: "#343536", // sidebars, menus
             "surface-bright": "#141516", // floating panels
             "surface-light": "#3C3C3C", // toolbars
-            "surface-variant": "#141516", // tooltip background
+            "surface-variant": "#454545", // tooltip background
             "on-surface-variant": "#FFFFFF", // tooltip text
             "secondary-darken-1": "#0A0A0B", // overlay scrim
             "primary-text": "#FFFFFF",


### PR DESCRIPTION
The "Add to Selected Layers" button tooltip covered the layer name. Move the tooltip to the bottom as to not obscure the layer name.

<img width="234" alt="image" src="https://github.com/user-attachments/assets/1b5e5f44-d091-49ed-9c4f-5df0badd0574" />

This PR has no dependency on #122, but it is stacked on top so that I didn't have to stash my other changes.