### PR TITLE
Gracefully handle missing `Authorization` header

### DIFF
--- a/uvdat/core/rest/tokenauth.py
+++ b/uvdat/core/rest/tokenauth.py
@@ -6,21 +6,31 @@ from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 
 
 class TokenAuth(OAuth2Authentication):
+    @staticmethod
+    def get_token_from_query(request) -> str | None:
+        token = request.query_params.get('token')
+        if token is not None:
+            return token
+
+        auth_token = request.headers.get('Authorization')
+        if auth_token is not None:
+            return auth_token.replace('Token ', '')
+
     def authenticate(self, request):
         auth = super().authenticate(request)
         if auth is not None:
             return auth
-        token = request.query_params.get('token')
-        if token is None:
-            token_string = request.headers.get('Authorization')
-            token = token_string.replace('Token ', '')
-        if token is not None:
-            try:
-                user = User.objects.get(auth_token=token)
-            except User.DoesNotExist:
-                return None
 
-            if not user.is_active:
-                return None
-            return (user, None)
-        return None
+        token = self.get_token_from_query(request)
+        if token is None:
+            return None
+
+        try:
+            user = User.objects.get(auth_token=token)
+        except User.DoesNotExist:
+            return None
+
+        if not user.is_active:
+            return None
+
+        return (user, None)


### PR DESCRIPTION
Currently if you make a request to an endpoint that uses the `TokenAuth` class from swagger (or just your browser), it throws a `500 Internal Server Error`, because it expects the `Authorization` header to be present unconditionally. 