### PR TITLE
Use Sets to represent network nodes and edges

### DIFF
--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -110,12 +110,14 @@ export async function getNetworkEdges(networkId: number): Promise<NetworkEdge[]>
 export async function getNetworkGCC(
   networkId: number,
   exclude_nodes: number[]
-): Promise<number[]> {
-  return (
+): Promise<Set<number>> {
+  const nodes = (
     await apiClient.get(
       `networks/${networkId}/gcc?exclude_nodes=${exclude_nodes.toString()}`
     )
   ).data;
+
+  return new Set(nodes);
 }
 
 export async function getRasterDataValues(rasterId: number): Promise<RasterDataValues> {

--- a/web/src/api/rest.ts
+++ b/web/src/api/rest.ts
@@ -87,16 +87,28 @@ export async function getDatasetLayers(datasetId: number): Promise<Layer[]> {
   return (await apiClient.get(`datasets/${datasetId}/layers`)).data;
 }
 
+
+function processNetwork(data: Record<string, any>): Network {
+  return {
+    ...data,
+    nodes: new Set(data.nodes),
+    edges: new Set(data.edges),
+  } as Network
+}
+
 export async function getDatasetNetworks(datasetId: number): Promise<Network[]> {
-  return (await apiClient.get(`datasets/${datasetId}/networks`)).data;
+  const { data } = (await apiClient.get(`datasets/${datasetId}/networks`)).data;
+  return data.map((network: any) => processNetwork(network));
 }
 
 export async function getProjectNetworks(projectId: number): Promise<Network[]> {
-  return (await apiClient.get(`networks/?project=${projectId}`)).data.results;
+  const { data: { results } } = (await apiClient.get(`networks/?project=${projectId}`));
+  return results.map((network: any) => processNetwork(network));
 }
 
 export async function getNetwork(networkId: number): Promise<Network> {
-  return (await apiClient.get(`networks/${networkId}`)).data;
+  const { data } = (await apiClient.get(`networks/${networkId}`));
+  return processNetwork(data);
 }
 
 export async function getNetworkNodes(networkId: number): Promise<NetworkNode[]> {

--- a/web/src/components/map/MapTooltip.vue
+++ b/web/src/components/map/MapTooltip.vue
@@ -125,7 +125,7 @@ const clickedFeatureIsDeactivatedNode = computed(
   () =>
     clickedFeature.value &&
     availableNetworks.value.find((network) => {
-      return network.deactivated?.nodes.includes(
+      return network.deactivated?.nodes.has(
         clickedFeature.value?.feature.properties.node_id
       )
     })

--- a/web/src/components/sidebars/NodeAnimation.vue
+++ b/web/src/components/sidebars/NodeAnimation.vue
@@ -55,7 +55,7 @@ function rewind() {
 watch(currentTick, async () => {
   if (nodeChanges.value) {
     let deactivated = nodeChanges.value[currentTick.value];
-    if (props.network) setNetworkDeactivatedNodes(props.network, deactivated || [], true);
+    if (props.network) setNetworkDeactivatedNodes(props.network, new Set(deactivated), true);
     if (props.additionalAnimationLayers) {
       props.additionalAnimationLayers.forEach((layer) => {
         const currentStyle = selectedLayerStyles.value[`${layer.id}.${layer.copy_id || 0}`];

--- a/web/src/layerStyles.ts
+++ b/web/src/layerStyles.ts
@@ -145,7 +145,7 @@ export function styleNetwork(network: Network) {
                     const inactive = Array.from(network.deactivated?.nodes || []).filter((n) => (
                         !deactivate?.includes(n) && !activate?.includes(n)
                     )) || [];
-                    let gcc = network.gcc || []
+                    let gcc = Array.from(network.gcc || []);
                     if (
                         !inactive.length &&
                         !deactivate.length &&

--- a/web/src/layerStyles.ts
+++ b/web/src/layerStyles.ts
@@ -150,7 +150,7 @@ export function styleNetwork(network: Network) {
                         !inactive.length &&
                         !deactivate.length &&
                         !activate.length &&
-                        gcc.length === network.nodes.length
+                        gcc.length === network.nodes.size
                     ) {
                         // Network default state; don't show GCC
                         gcc = []

--- a/web/src/layerStyles.ts
+++ b/web/src/layerStyles.ts
@@ -139,9 +139,10 @@ export function styleNetwork(network: Network) {
                     const inactiveValue = style.inactive || style.default;
                     const deactivateValue = style.deactivate || style.default;
                     const activateValue = style.activate || style.default;
-                    const deactivate = network.changes?.deactivate_nodes || [];
-                    const activate = network.changes?.activate_nodes || [];
-                    const inactive = network.deactivated?.nodes.filter((n) => (
+
+                    const deactivate = Array.from(network.changes?.deactivate_nodes || []);
+                    const activate = Array.from(network.changes?.activate_nodes || []);
+                    const inactive = Array.from(network.deactivated?.nodes || []).filter((n) => (
                         !deactivate?.includes(n) && !activate?.includes(n)
                     )) || [];
                     let gcc = network.gcc || []
@@ -182,8 +183,8 @@ export function styleNetwork(network: Network) {
                             inactiveValue,
                             [
                                 "any",
-                                ["in", ["get", "node_id"], ["literal", network.selected?.nodes || []]],
-                                ["in", ["get", "edge_id"], ["literal", network.selected?.edges || []]],
+                                ["in", ["get", "node_id"], ["literal", Array.from(network.selected?.nodes || [])]],
+                                ["in", ["get", "edge_id"], ["literal", Array.from(network.selected?.edges || [])]],
                             ],
                             selectedValue,
                             [

--- a/web/src/layerStyles.ts
+++ b/web/src/layerStyles.ts
@@ -143,8 +143,9 @@ export function styleNetwork(network: Network) {
                     const deactivate = Array.from(network.changes?.deactivate_nodes || []);
                     const activate = Array.from(network.changes?.activate_nodes || []);
                     const inactive = Array.from(network.deactivated?.nodes || []).filter((n) => (
-                        !deactivate?.includes(n) && !activate?.includes(n)
-                    )) || [];
+                        !network.changes?.deactivate_nodes?.has(n) &&
+                        !network.changes?.activate_nodes?.has(n)
+                    ));
                     let gcc = Array.from(network.gcc || []);
                     if (
                         !inactive.length &&

--- a/web/src/networks.ts
+++ b/web/src/networks.ts
@@ -77,7 +77,7 @@ export async function getNetwork(
 ): Promise<Network | undefined> {
     let network;
     availableNetworks.value.forEach((net) => {
-        if (net.nodes.includes(nodeId)) {
+        if (net.nodes.has(nodeId)) {
             network = net;
         }
     })
@@ -90,7 +90,7 @@ export async function getNetwork(
         ]
     }
     availableNetworks.value.forEach((net) => {
-        if (net.nodes.includes(nodeId)) {
+        if (net.nodes.has(nodeId)) {
             network = net;
         }
     })

--- a/web/src/networks.ts
+++ b/web/src/networks.ts
@@ -9,7 +9,7 @@ import { styleNetwork } from "./layerStyles";
 
 interface GCCResult {
     deactivatedNodes: number[],
-    gcc: number[],
+    gcc: Set<number>,
 }
 const GCCcache: GCCResult[] = [];
 
@@ -62,7 +62,7 @@ export async function setNetworkDeactivatedNodes(network: Network, nodeIds: Set<
             })
         }
     } else {
-        network.gcc = network.nodes
+        network.gcc = new Set(network.nodes);
     }
     styleNetwork(network)
     availableNetworks.value = availableNetworks.value.map((n) => {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -189,16 +189,16 @@ export interface Network {
   metadata: Record<string, unknown>;
   vector_data: number;
   selected?: {
-    nodes: number[];
-    edges: number[];
+    nodes: Set<number>;
+    edges: Set<number>;
   },
   deactivated?: {
-    nodes: number[];
-    edges: number[];
+    nodes: Set<number>;
+    edges: Set<number>;
   };
   changes?: {
-    deactivate_nodes: number[];
-    activate_nodes: number[];
+    deactivate_nodes: Set<number>;
+    activate_nodes: Set<number>;
   }
   gcc: number[];
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -200,7 +200,7 @@ export interface Network {
     deactivate_nodes: Set<number>;
     activate_nodes: Set<number>;
   }
-  gcc: number[];
+  gcc?: Set<number>;
 }
 
 export interface NetworkNode {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -184,8 +184,8 @@ export interface Network {
   name: string;
   dataset: Dataset;
   category: string;
-  nodes: number[];
-  edges: number[];
+  nodes: Set<number>;
+  edges: Set<number>;
   metadata: Record<string, unknown>;
   vector_data: number;
   selected?: {


### PR DESCRIPTION
Since we perform a lot of operations with network nodes and edges, storing them as an array can be a bit cumbersome both mentally and from a performance standpoint (since simply finding a node in a list requires an O(n) operation). Sets allow for quicker lookups, but more importantly, they also allow for more intuitive and performant operations between groups of nodes. For example, if you wanted to find the common nodes between two groups of nodes, with arrays, it would be something like:

```javascript
const commonNodes = groupA.filter((node) => groupB.includes(node));
```

which has quadratic time complexity. With a set, the code is:

```javascript
const commonNodes = groupA.intersection(groupB);
```

which is of linear time complexity (and easier to read imo).

This extends to more complex examples that are easy to articulate with set functions, but become complicated when working with two arrays.
