### PR TITLE
Copy array when setting network deactivated nodes

### DIFF
--- a/web/src/networks.ts
+++ b/web/src/networks.ts
@@ -23,7 +23,7 @@ export async function toggleNodeActive(
 ) {
     const network = await getNetwork(nodeId, dataset);
     if (network) {
-        let deactivated = network?.deactivated?.nodes || []
+        let deactivated = Array.from(network?.deactivated?.nodes || []);
         if (!deactivated.includes(nodeId)) {
             deactivated.push(nodeId)
         } else {
@@ -44,7 +44,7 @@ export async function setNetworkDeactivatedNodes(network: Network, nodeIds: numb
             activate_nodes: network.deactivated.nodes.filter((n) => !nodeIds.includes(n))
         }
     }
-    network.deactivated.nodes = nodeIds;
+    network.deactivated.nodes = Array.from(nodeIds);
     if (nodeIds.length) {
         const cachedResult = GCCcache.find(
             // sort and stringify to disregard order in comparison


### PR DESCRIPTION
I noticed after #131 was merged that the GCC network is only called on the first disabled node and never again. This is because we fetch the deactivated node list, and push or remove node IDs from it, pass that list to `setNetworkDeactivatedNodes`, and then set it back to `network.deactivated.nodes`. Because that list is never copied, it is always accessing the same underlying object. So when that object is looked up in `GCCcache`, it's always a cache hit, because the list is always being matched against itself, leading to a skipped call to `/gcc`.

This PR just copies the array whenever modifying or setting that node list. 