### PR TITLE
Only use opacity for visibility on multi-frame layers

### DIFF
--- a/web/src/store/layer.ts
+++ b/web/src/store/layer.ts
@@ -99,6 +99,7 @@ export const useLayerStore = defineStore('layer', () => {
 
     // reverse selected layers list for first on top
     selectedLayers.value.toReversed().forEach((layer) => {
+      const multiFrame = layer.frames.length > 1;
       layer.frames.forEach((frame) => {
         const styleId = `${layer.id}.${layer.copy_id}`
         const sourceId = `${styleId}.${frame.id}`
@@ -112,7 +113,7 @@ export const useLayerStore = defineStore('layer', () => {
         if (currentStyle.visible && !map.getLayersOrder().some(
           (mapLayerId) => mapLayerId.includes(sourceId)
         ) && layer.current_frame === frame.index) {
-          mapStore.addLayerFrameToMap(frame, sourceId);
+          mapStore.addLayerFrameToMap(frame, sourceId, multiFrame);
         }
 
         map.getLayersOrder().forEach((mapLayerId) => {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -181,6 +181,17 @@ export interface ClickedFeatureData {
   feature: MapGeoJSONFeature;
 }
 
+export interface MapLibreLayerMetadata {
+  layer_id: string;
+  layer_copy_id: string;
+  frame_id: string;
+  multiFrame: boolean;
+}
+
+export type MapLibreLayerWithMetadata = MapGeoJSONFeature["layer"] & {
+  metadata: MapLibreLayerMetadata;
+}
+
 export interface Network {
   id: number;
   name: string;


### PR DESCRIPTION
Closes #140

The primary way this is achieved is by adding a `multiFrame` metadata field to a layer upon creation, and then checking for that field when handling a layer click. Specifically, this is used to further filter out "clickable" layers, since any layer that is clicked but has an opacity of zero should also be removed from the list of "clickable" layers.