### PR TITLE
Install all large-image sources in Dockerfile

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -15,7 +15,7 @@ RUN python -m pip install ./tile2net
 COPY ./setup.py /opt/uvdat-server/setup.py
 COPY ./manage.py /opt/uvdat-server/manage.py
 COPY ./uvdat /opt/uvdat-server/uvdat
-RUN pip install large-image[gdal,pil,mapnik] large-image-converter --find-links https://girder.github.io/large_image_wheels
+RUN pip install large-image[all] large-image-converter --find-links https://girder.github.io/large_image_wheels
 RUN pip install --editable /opt/uvdat-server[dev]
 
 # Use a directory name which will never be an import name, as isort considers this as first-party.


### PR DESCRIPTION
Instead of only installing the GDAL, PIL, and Mapnik sources in our Dockerfile (used for our Django and Celery containers), this PR changes the Dockerfile to install all large-image sources.