### PR TITLE
Update populate script

### DIFF
--- a/sample_data/ingest_use_case.py
+++ b/sample_data/ingest_use_case.py
@@ -95,7 +95,7 @@ def ingest_projects(use_case):
             project_for_setting.set_permissions(owner=superuser)
 
 
-def ingest_charts(use_case):
+def ingest_charts(use_case, no_cache=False):
     chart_file_path = USE_CASE_FOLDER / use_case / 'charts.json'
     if chart_file_path.exists():
         print('Creating Chart objects...')
@@ -104,9 +104,15 @@ def ingest_charts(use_case):
             for chart in data:
                 print('\t- ', chart['name'])
                 existing = Chart.objects.filter(name=chart['name'])
+                create_new = True
                 if existing.count():
-                    chart_for_conversion = existing.first()
-                else:
+                    if no_cache:
+                        existing.delete()
+                    else:
+                        chart_for_conversion = existing.first()
+                        create_new = False
+
+                if create_new:
                     new_chart = Chart.objects.create(
                         name=chart['name'],
                         description=chart['description'],
@@ -193,4 +199,4 @@ def ingest_use_case(use_case_name, include_large=False, no_cache=False, dataset_
         dataset_indexes=dataset_indexes,
     )
     ingest_projects(use_case=use_case_name)
-    ingest_charts(use_case=use_case_name)
+    ingest_charts(use_case=use_case_name, no_cache=no_cache)

--- a/sample_data/ingest_use_case.py
+++ b/sample_data/ingest_use_case.py
@@ -32,13 +32,17 @@ def ingest_file(file_info, index=0, dataset=None, chart=None, no_cache=False):
     file_location = Path(DOWNLOADS_FOLDER, file_path)
     file_type = file_path.split('.')[-1]
     file_location.parent.mkdir(parents=True, exist_ok=True)
-    pooch.retrieve(
-        url=file_url,
-        fname=file_location.name,
-        path=file_location.parent,
-        known_hash=file_hash,
-        progressbar=True,
-    )
+
+    if file_url is not None:
+        pooch.retrieve(
+            url=file_url,
+            fname=file_location.name,
+            path=file_location.parent,
+            known_hash=file_hash,
+            progressbar=True,
+        )
+    elif not file_location.exists():
+        raise Exception('File path does not exist and no download URL was specified.')
 
     create_new = True
     existing = FileItem.objects.filter(dataset=dataset, name=file_name)

--- a/sample_data/use_cases/boston_floods/charts.json
+++ b/sample_data/use_cases/boston_floods/charts.json
@@ -6,6 +6,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64beb508b4d956782eee8cb1/download",
+                "hash": "299afb2e6726024cc943c0267507cae7b635282db358fea688be81b569f0b9db",
                 "path": "boston/tide_level_data.csv"
             }
         ],
@@ -62,6 +63,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/67d9a34e429cb34d95af01c5/download",
+                "hash": "0af8013362c94a3d043c88a277abcbf8e2c44999812f7b8da33dd18e4b22686e",
                 "path": "boston/parabolic_hyetograph.csv"
             }
         ],
@@ -90,6 +92,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/67d9a34e429cb34d95af01c2/download",
+                "hash": "aa83acf52af4dcc8e384fda18bcbba5d85d84ffdd30314950e8aacce772111e7",
                 "path": "boston/ncrs_type_2_hyetograph.csv"
             }
         ],

--- a/sample_data/use_cases/boston_floods/datasets.json
+++ b/sample_data/use_cases/boston_floods/datasets.json
@@ -6,6 +6,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64b95be1cf6a0eaef6c141f6/download",
+                "hash": "1a8d1a602e7880d091a156b3b97a47d453260ba41c7c4e6e872ca4543453985d",
                 "path": "boston/mbta_rapid_transit.zip",
                 "metadata": {
                     "combine_contents": "true"
@@ -25,6 +26,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64907c77f04fb368544295ed/download",
+                "hash": "57158adcedb10e6e8db680d2b031556ad7ff31b2e936ac29679b5e68746aa2e0",
                 "path": "boston/commuter_rail.zip",
                 "metadata": {
                     "combine_contents": "true"
@@ -39,6 +41,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64907b6ef04fb368544295e7/download",
+                "hash": "fd69257c873ebf26b2b2ff0be175791a56217c443a4d3719b517b7e99f7a879a",
                 "path": "boston/hurr_inun.zip"
             }
         ]
@@ -50,6 +53,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64907beff04fb368544295ea/download",
+                "hash": "78029d00da91d476ca131e5fcf7bc3796dfc0dc4a94201b64acf956ef9597ca7",
                 "path": "boston/flood_hazard_fema.zip"
             }
         ]
@@ -61,6 +65,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64907e4df04fb368544295f0/download",
+                "hash": "fceb76454c786d4e5ad6e05220073a0009e8deb008f5fd9195ff21c432fb8682",
                 "path": "boston/easternmass.tif"
             }
         ],
@@ -83,10 +88,12 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/6744df3c22f196cb5d931161/download",
+                "hash": "ea35f2e3d2c5dc0b2d3621ea66c1faf23632a2e1de6438cd2303e1896f75f4d4",
                 "path": "boston/boston_orthoimagery.tiff"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/677c69b537ed172242a867b1/download",
+                "hash": "50a6a71f7f51dcb63d9590ff7c0adccd95e709fa5f4cfce30466002c41069557",
                 "path": "boston/orthoimagery_tiles.zip"
             }
         ],
@@ -175,6 +182,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64caa3da77edef4e1ea8ef57/download",
+                "hash": "9917afa67c77b3f7a4e13637b21af60ec348cee0cd18bca92a0c87adf9d7134f",
                 "path": "boston/neighborhoods2020.json"
             }
         ],
@@ -189,6 +197,7 @@
         "files": [
             {
                 "url": "https://data.boston.gov/dataset/c478b600-3e3e-46fd-9f57-da89459e9928/resource/11282722-9386-4272-8a82-2fcec89e6d55/download/census2020_blockgroups.zip",
+                "hash": "98d6346c117ea2bf6e7da3a382f88e75e3a028fd395fe4419a46022e76c2cf50",
                 "path": "mass/blockgroups.zip"
             }
         ],
@@ -203,6 +212,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64fbb4c6e99e9e6006f00114/download",
+                "hash": "44ea42d43c6699118e6e9b4d4939ecc1fde95f1150b9d288842efbd9900eaa3f",
                 "path": "boston/zipcodes.zip"
             }
         ],
@@ -217,38 +227,47 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64f8743d6725af35134c1479/download",
+                "hash": "9c95774905bb4d8f7bbcf4773b63793b09628c4b5d660a0de2610933379fb3b8",
                 "path": "boston/9in_rise.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f874486725af35134c147c/download",
+                "hash": "31084ff9275078a972af1b485cc412b996ecf657c0c2532d1bd01f893d5f6c13",
                 "path": "boston/21in_rise.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f874566725af35134c147f/download",
+                "hash": "36aa2821efc76fd32947b337303b450d80099734fa469c845226129a463ec7c9",
                 "path": "boston/36in_rise.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f87ba86725af35134c1485/download",
+                "hash": "4adec3a2a9fe2fc5d3822248ce8bcc8bf0ff4e499895df66039cc60a87295c09",
                 "path": "boston/9in_10yr_flood.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f87bd56725af35134c148b/download",
+                "hash": "8089ac4ab7339748e8101600ab30aa2670fb148202c442d8973c6f49232d49e2",
                 "path": "boston/21in_10yr_flood.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f87bfd6725af35134c1491/download",
+                "hash": "361107ef2607a9416834d4cc9d0937bbef7aa615b2c55349edcc463d0afb5056",
                 "path": "boston/36in_10yr_flood.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f87bc16725af35134c1488/download",
+                "hash": "2d0f5861099b14c9ff258695c54d2af10ec4dc2f742191a3be77e4fdd821138e",
                 "path": "boston/9in_100yr_flood.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f87be96725af35134c148e/download",
+                "hash": "f02447fac9168e848f890305b65731705cd84b42582a150c047cba5fe2009b9b",
                 "path": "boston/21in_100yr_flood.geojson"
             },
             {
                 "url": "https://data.kitware.com/api/v1/item/64f87c496725af35134c1494/download",
+                "hash": "aa33b5cfd1c260c0a684df1003d44b3eb813de81095e833d695a00fa6651958c",
                 "path": "boston/36in_100yr_flood.geojson"
             }
         ],
@@ -313,6 +332,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/64b80188cf6a0eaef6c1416e/download",
+                "hash": "d0d4c957a7571402ce102d47cb53a3bddee11b0c8f278f509dc5615a9810c83f",
                 "path": "washington/DC_Metro.zip",
                 "metadata": {
                     "combine_contents": "true"

--- a/sample_data/use_cases/la_wildfires/datasets.json
+++ b/sample_data/use_cases/la_wildfires/datasets.json
@@ -7,10 +7,10 @@
         "files": [
             {
                 "path": "la-fire-2025/modis-1-48.zip",
-                "url": "https://data.kitware.com/api/v1/item/67aa368b091a514e82eec908/download"
+                "url": "https://data.kitware.com/api/v1/item/67aa368b091a514e82eec908/download",
+                "hash": "5271a47008fdd75b8bd9d3df453ece9eae27d6bbe3050cbf8c00e486edd286e4"
             }
-        ],
-        "style_options": {}
+        ]
     },
     {
         "name": "USA Current Wildfire Perimeters",
@@ -20,7 +20,8 @@
         "files": [
             {
                 "path": "la-fire-2025/current_fire_perimeters.geojson",
-                "url": "https://data.kitware.com/api/v1/item/67aa368c091a514e82eec90b/download"
+                "url": "https://data.kitware.com/api/v1/item/67aa368c091a514e82eec90b/download",
+                "hash": "781b75f35db48ac53a917a524809f87108cd183941deaefe2503e128f86e465e"
             }
         ]
     },
@@ -32,10 +33,10 @@
         "files": [
             {
                 "path": "la-fire-2025/current_fire_incidents.geojson",
-                "url": "https://data.kitware.com/api/v1/item/67aa368c091a514e82eec90e/download"
+                "url": "https://data.kitware.com/api/v1/item/67aa368c091a514e82eec90e/download",
+                "hash": "649f641ec200ff2bb64f12ba3928e289cc35fcfc942fc16b5890dc3382ce4a79"
             }
-        ],
-        "style_options": {}
+        ]
     },
     {
         "name": "California Fire Perimeters",
@@ -45,10 +46,10 @@
         "files": [
             {
                 "path": "la-fire-2025/ca_perimeters_nifc_firis.geojson",
-                "url": "https://data.kitware.com/api/v1/item/67aa33ed091a514e82eec8ff/download"
+                "url": "https://data.kitware.com/api/v1/item/67aa33ed091a514e82eec8ff/download",
+                "hash": "53fdb0484bd05725fe1569302ebd7c66404d93e9f8772bf557473f6e59c3a02a"
             }
-        ],
-        "style_options": {}
+        ]
     },
     {
         "name": "Palisades Satellite Imagery",
@@ -58,10 +59,10 @@
         "files": [
             {
                 "path": "la-fire-2025/palidades-2025-01-14.tif",
-                "url": "https://data.kitware.com/api/v1/item/67aa368a091a514e82eec905/download"
+                "url": "https://data.kitware.com/api/v1/item/67aa368a091a514e82eec905/download",
+                "hash": "7630707f87a54ae134ec56012911884c5648d55419c8742e264c4d4c4354ea1f"
             }
-        ],
-        "style_options": {}
+        ]
     },
     {
         "name": "Eaton/Altadena Satellite Imagery",
@@ -71,9 +72,9 @@
         "files": [
             {
                 "path": "la-fire-2025/eaton-2025-01-14_to_19.tif",
-                "url": "https://data.kitware.com/api/v1/item/67aa353a091a514e82eec902/download"
+                "url": "https://data.kitware.com/api/v1/item/67aa353a091a514e82eec902/download",
+                "hash": "163a8b84bf7fb356b66ff2700ec0d2043c25a9a153f7778e84b9b85ca51dcf74"
             }
-        ],
-        "style_options": {}
+        ]
     }
 ]

--- a/sample_data/use_cases/la_wildfires/ingest.py
+++ b/sample_data/use_cases/la_wildfires/ingest.py
@@ -1,7 +1,6 @@
 def convert_dataset(dataset, options):
     print('\t', f'Converting data for {dataset.name}...')
     dataset.spawn_conversion_task(
-        style_options=options.get('style_options'),
         network_options=options.get('network_options'),
         region_options=options.get('region_options'),
         asynchronous=False,

--- a/sample_data/use_cases/new_york_energy/datasets.json
+++ b/sample_data/use_cases/new_york_energy/datasets.json
@@ -11,6 +11,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/66a2a19a5d2551c516b1e502/download",
+                "hash": "32f44d7d9f3571185ce2c9e1d28fb90987ddbebb13923a887e1733e2f1c84c89",
                 "path": "nyc/counties.zip"
             }
         ],
@@ -30,6 +31,7 @@
         "files": [
             {
                 "url": "https://data.kitware.com/api/v1/item/66cdd8a6886c56bdc7e282a4/download",
+                "hash": "3f7e8c036cf7fbd1f10fd25b34e76d7c4b10ae9b985a148316b4a826336c4ad5",
                 "path": "nyc/networks.zip"
             }
         ]

--- a/sample_data/use_cases/test/datasets.json
+++ b/sample_data/use_cases/test/datasets.json
@@ -6,6 +6,7 @@
     "files": [
       {
         "url": "https://data.kitware.com/api/v1/item/6841f7e0dfcff796fee73d1a/download",
+        "hash": "9c24922c9d95fd49f8fd3bafa7ed60f093ac292891a4301bac2be883eeef65ee",
         "path": "test/multiframe_vector.geojson"
       }
     ],
@@ -22,6 +23,7 @@
     "files": [
       {
         "url": "https://data.kitware.com/api/v1/item/6841f7e0dfcff796fee73d1a/download",
+        "hash": "9c24922c9d95fd49f8fd3bafa7ed60f093ac292891a4301bac2be883eeef65ee",
         "path": "test/multiframe_vector.geojson"
       }
     ],

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'osmnx==1.9.4',
         'geopandas==0.14.4',
         'networkx==3.3',
+        'pooch==1.8.2',
         'pyshp==2.3.1',
         'rasterio==1.3.10',
         'urllib3==1.26.15',

--- a/uvdat/core/management/commands/populate.py
+++ b/uvdat/core/management/commands/populate.py
@@ -17,11 +17,17 @@ class Command(BaseCommand):
             action='store_true',
             help='Include conversion step for large datasets',
         )
+        parser.add_argument(
+            '--no_cache',
+            action='store_true',
+            help='Do not reuse existing files and datasets',
+        )
         parser.add_argument('--dataset_indexes', nargs='*', type=int)
 
     def handle(self, *args, **kwargs):
         use_case_name = kwargs['use_case']
         include_large = kwargs['include_large']
+        no_cache = kwargs['no_cache']
         dataset_indexes = kwargs['dataset_indexes']
         if dataset_indexes is None or len(dataset_indexes) == 0:
             dataset_indexes = None
@@ -29,5 +35,6 @@ class Command(BaseCommand):
         ingest_use_case(
             use_case_name,
             include_large=include_large,
+            no_cache=no_cache,
             dataset_indexes=dataset_indexes,
         )

--- a/uvdat/core/tasks/conversion.py
+++ b/uvdat/core/tasks/conversion.py
@@ -100,8 +100,9 @@ def convert_files(*files, file_item=None, combine=False):
         data, features = geodata.get('data'), geodata.get('features')
         if data is None and len(features):
             gdf = geopandas.GeoDataFrame.from_features(features)
-            gdf = gdf.set_crs(source_projection, allow_override=True)
-            gdf = gdf.to_crs(4326)
+            if source_projection is not None:
+                gdf = gdf.set_crs(source_projection, allow_override=True)
+                gdf = gdf.to_crs(4326)
             data = json.loads(gdf.to_json())
         vector_data = VectorData.objects.create(
             name=geodata.get('name'),


### PR DESCRIPTION
Using [pooch](https://github.com/fatiando/pooch) for downloading data files uses file hashes to ensure that downloaded files are correct and complete. Resolves #107.

Adding the `--no_cache` argument to the populate command allows the user to force deletion of existing Datasets, FileItems, and Charts and create new ones. Resolves #157.