### PR TITLE
Standardize handling of source and layer IDs

### DIFF
--- a/web/src/store/map.ts
+++ b/web/src/store/map.ts
@@ -9,6 +9,7 @@ import {
   LayerFrame,
   MapLibreLayerWithMetadata,
   MapLibreLayerMetadata,
+  Layer,
 } from '@/types';
 import { Map, MapLayerMouseEvent, Popup, Source, LayerSpecification } from "maplibre-gl";
 import { getRasterDataValues } from '@/api/rest';
@@ -37,6 +38,34 @@ function getLayerIsVisible(layer: MapLibreLayerWithMetadata) {
 
 function sourceIdFromMapLayerId(mapLayerId: string) {
   return mapLayerId.split('.').slice(0, -1).join('.');
+}
+
+function uniqueLayerIdFromLayer(layer: Layer) {
+  return `${layer.id}.${layer.copy_id}`;
+}
+
+/**
+ * Note: Rasters also have an extra `bounds` source, which allows for
+ * interaction with the raster layer. This is not considered in this
+ * function, as it's rarely accessed directly.
+ */
+function sourceIdFromLayerFrame(layer: Layer, frame: LayerFrame) {
+  const parts: (number | string)[] = [
+    uniqueLayerIdFromLayer(layer),
+    frame.id,
+  ]
+
+  if (frame.vector) {
+    parts.push('vector');
+    parts.push(frame.vector.id);
+  } else if (frame.raster) {
+    parts.push('raster');
+    parts.push(frame.raster.id);
+  } else {
+    throw new Error("Layer frame is neither raster nor vector!");
+  }
+
+  return parts.join('.');
 }
 
 
@@ -425,5 +454,7 @@ export const useMapStore = defineStore('map', () => {
     sourceIdFromMapLayerId,
     parseSourceString,
     parseLayerString,
+    sourceIdFromLayerFrame,
+    uniqueLayerIdFromLayer,
   }
 });

--- a/web/src/store/style.ts
+++ b/web/src/store/style.ts
@@ -308,9 +308,9 @@ export const useStyleStore = defineStore('style', () => {
         if (!currentFrame) return
         map.getLayersOrder().forEach((mapLayerId) => {
             if (mapLayerId !== 'base-tiles') {
-                const [layerId, layerCopyId, frameId] = mapLayerId.split('.');
-                if (parseInt(layerId) === layer.id && parseInt(layerCopyId) === layer.copy_id) {
-                    if (parseInt(frameId) === currentFrame.id) {
+                const { layerId, layerCopyId, frameId } = mapStore.parseLayerString(mapLayerId);
+                if (layerId === layer.id && layerCopyId === layer.copy_id) {
+                    if (frameId === currentFrame.id) {
                         map.setLayoutProperty(mapLayerId, 'visibility', layer.visible ? 'visible' : 'none');
                         const styleKey = `${layer.id}.${layer.copy_id}`
                         const currentStyleSpec: StyleSpec = selectedLayerStyles.value[styleKey];
@@ -335,7 +335,7 @@ export const useStyleStore = defineStore('style', () => {
         vector: VectorData | null
     ) {
         const map = mapStore.getMap();
-        const sourceId = mapLayerId.split('.').slice(0, -1).join('.')
+        const sourceId = mapStore.sourceIdFromMapLayerId(mapLayerId);
         const { network } = layerStore.getDBObjectsForSourceID(sourceId)
 
         let filters: StyleFilter[] = styleSpec.filters
@@ -420,7 +420,7 @@ export const useStyleStore = defineStore('style', () => {
         const map = mapStore.getMap();
         map.getLayersOrder().forEach((mapLayerId) => {
             if (mapLayerId.includes(".vector." + vectorId)) {
-                const [layerId, layerCopyId] = mapLayerId.split('.');
+                const { layerId, layerCopyId } = mapStore.parseLayerString(mapLayerId);
                 const currentStyle = selectedLayerStyles.value[`${layerId}.${layerCopyId}`];
                 // TODO: put this back when types are consistent
                 // let defaultColor = currentStyle.color || 'black'

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -250,9 +250,9 @@ export interface ClickedFeatureData {
 }
 
 export interface MapLibreLayerMetadata {
-  layer_id: string;
-  layer_copy_id: string;
-  frame_id: string;
+  layer_id: number;
+  layer_copy_id: number;
+  frame_id: number;
   multiFrame: boolean;
 }
 


### PR DESCRIPTION
Our current method of parsing layer and source IDs is done ad hoc everywhere it's needed. This PR introduces well defined functions for parsing source and layer IDs into their constituent parts.